### PR TITLE
fix: show package names for permissive licenses in SBOM license break…

### DIFF
--- a/backend/internal/clickhouse/queries_search.go
+++ b/backend/internal/clickhouse/queries_search.go
@@ -51,6 +51,7 @@ func (c *Client) QuerySBOMVulnerabilities(ctx context.Context, sbomID string) ([
 
 // QuerySBOMLicenses fetches the license breakdown for a specific SBOM.
 func (c *Client) QuerySBOMLicenses(ctx context.Context, sbomID string) ([]dto.SBOMLicenseBreakdownItem, error) {
+	// Step 1: Get the license compliance summary (categories, exemptions).
 	rows, err := c.Conn.Query(ctx, `
 		SELECT license_id, category, package_count, non_compliant_packages,
 		       exempted_packages, exemption_reason
@@ -66,11 +67,13 @@ func (c *Client) QuerySBOMLicenses(ctx context.Context, sbomID string) ([]dto.SB
 	var items []dto.SBOMLicenseBreakdownItem
 	for rows.Next() {
 		var item dto.SBOMLicenseBreakdownItem
+		var nonCompliant []string
 		var exempted []string
 		var reason string
-		if err := rows.Scan(&item.LicenseID, &item.Category, &item.PackageCount, &item.Packages, &exempted, &reason); err != nil {
+		if err := rows.Scan(&item.LicenseID, &item.Category, &item.PackageCount, &nonCompliant, &exempted, &reason); err != nil {
 			return nil, fmt.Errorf("failed to scan license row: %w", err)
 		}
+		item.Packages = nonCompliant
 		if len(exempted) > 0 {
 			item.ExemptedPackages = exempted
 			item.ExemptionReason = reason
@@ -80,7 +83,64 @@ func (c *Client) QuerySBOMLicenses(ctx context.Context, sbomID string) ([]dto.SB
 	if items == nil {
 		items = []dto.SBOMLicenseBreakdownItem{}
 	}
+
+	// Step 2: For items where the package list is empty (typically permissive
+	// licenses where non_compliant_packages is always []), resolve the actual
+	// package names from sbom_packages by matching on the license array.
+	needsResolve := false
+	for _, it := range items {
+		if len(it.Packages) == 0 && it.PackageCount > 0 {
+			needsResolve = true
+			break
+		}
+	}
+	if needsResolve {
+		pkgMap, err := c.resolvePackagesByLicense(ctx, sbomID)
+		if err == nil {
+			for i := range items {
+				if len(items[i].Packages) == 0 && items[i].PackageCount > 0 {
+					if pkgs, ok := pkgMap[items[i].LicenseID]; ok {
+						items[i].Packages = pkgs
+					}
+				}
+			}
+		}
+	}
+
 	return items, nil
+}
+
+// resolvePackagesByLicense returns a map of license_id → []package_name by
+// exploding the parallel arrays in sbom_packages.
+func (c *Client) resolvePackagesByLicense(ctx context.Context, sbomID string) (map[string][]string, error) {
+	rows, err := c.Conn.Query(ctx, `
+		SELECT pkg_license, groupArray(pkg_name) AS pkg_names
+		FROM (
+			SELECT pkg_name, pkg_license
+			FROM sbom_packages FINAL
+			ARRAY JOIN
+				package_names    AS pkg_name,
+				package_licenses AS pkg_license
+			WHERE sbom_id = ?
+			  AND pkg_name != ''
+		)
+		GROUP BY pkg_license
+	`, sbomID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string][]string)
+	for rows.Next() {
+		var license string
+		var names []string
+		if err := rows.Scan(&license, &names); err != nil {
+			continue
+		}
+		result[license] = names
+	}
+	return result, nil
 }
 
 // QuerySBOMDetail fetches detailed info for a single SBOM with severity breakdown.


### PR DESCRIPTION
…down
## Description 

The license detail view showed 'No individual package details available' for permissive licenses (MIT, Apache-2.0, BSD-3-Clause) because the query only read non_compliant_packages from license_compliance — which is always empty for permissive licenses by design.
Now resolves actual package names from sbom_packages by ARRAY JOIN on package_names/package_licenses when the non_compliant list is empty but package_count > 0.



<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure / CI / Helm

## Component(s) Affected

- [x] API Gateway
- [ ] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [ ] Helm Chart
- [ ] Documentation

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## How Has This Been Tested?

<!-- Describe the tests that you ran. -->

- [x] `go test ./...` passes
- [ ] `ng build` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes

## Checklist

- [x ] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [X] I have signed off my commits (DCO)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes. -->

