### PR TITLE
fix: use correct SHA hashes for pinned GitHub Actions

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -50,7 +50,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198e362a7a4b04 # v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ matrix.component.context }}
           target: ${{ matrix.component.target || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and push
         id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198e362a7a4b04 # v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ matrix.component.context }}
           target: ${{ matrix.component.target || '' }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: EndBug/label-sync@52074158190acb45f3f9dc67a08bf9c43f5fc6ef # v2.3.3
+      - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yml
           delete-other-labels: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Frontend Test:   cd ui && npx ng test            # uses Vitest
 
 ## Supply Chain Security (OpenSSF Scorecard)
 - **Signed Releases**: All container images are signed with [cosign](https://github.com/sigstore/cosign) (keyless/OIDC via Fulcio) and attested with SLSA provenance (`actions/attest-build-provenance`) in `.github/workflows/release.yml`.
-- **Pinned Dependencies**: All GitHub Actions are pinned by full SHA hash (not tags). External downloads (e.g., Hugo in `deploy-docs.yml`) include SHA256 checksum verification.
+- **Pinned Dependencies**: All GitHub Actions are pinned by full SHA hash (not tags). When adding or updating a pinned action, **always verify the SHA against the GitHub API** (e.g., `gh api repos/{owner}/{action}/git/refs/tags/{version}`) before committing — never invent or guess SHA hashes. External downloads (e.g., Hugo in `deploy-docs.yml`) include SHA256 checksum verification.
 - **Fuzzing**: Native Go fuzz tests exist for SPDX and VEX parsers (`internal/spdx/fuzz_test.go`, `internal/vex/fuzz_test.go`). The `.github/workflows/fuzz.yml` workflow runs them weekly and on PRs touching `backend/`.
 - **SAST**: CodeQL runs on every push/PR for Go and TypeScript (`.github/workflows/codeql.yml`).
 - **Scorecard**: The `.github/workflows/scorecard.yml` workflow runs the OpenSSF Scorecard weekly and publishes results as SARIF to GitHub Security tab.


### PR DESCRIPTION
## Description
Fix incorrect SHA hashes for pinned GitHub Actions that caused the v0.3.0 release workflow to fail with `unable to find version`.
- `docker/build-push-action`: SHA was corrupted (typo), fixed to actual v6.18.0 commit
- `EndBug/label-sync`: SHA was incorrect, fixed to actual v2.3.3 commit
- Updated `AGENTS.md` to enforce SHA verification via GitHub API before committing
## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
## Component(s) Affected
- [x] Documentation
## How Has This Been Tested?
- [x] Verified both SHAs against GitHub API (`gh api repos/{owner}/{action}/git/refs/tags/{version}`)
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)