### PR TITLE
fix: correct mikebom binary path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,8 @@ jobs:
           curl -sL "https://github.com/kusari-sandbox/mikebom/releases/download/${MIKEBOM_VERSION}/mikebom-${MIKEBOM_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o mikebom.tar.gz
           echo "${MIKEBOM_SHA256}  mikebom.tar.gz" | sha256sum -c -
           tar -xzf mikebom.tar.gz
-          chmod +x mikebom
-          sudo mv mikebom /usr/local/bin/
+          chmod +x "mikebom-${MIKEBOM_VERSION}-x86_64-unknown-linux-gnu/mikebom"
+          sudo mv "mikebom-${MIKEBOM_VERSION}-x86_64-unknown-linux-gnu/mikebom" /usr/local/bin/
 
       - name: Generate SBOM
         run: |


### PR DESCRIPTION
## Description
The mikebom tarball extracts into a subdirectory (`mikebom-{version}-x86_64-unknown-linux-gnu/mikebom`), not the CWD. This caused the v0.3.1 release workflow to fail with `chmod: cannot access 'mikebom': No such file or directory`.
## Type of Change
- [x] 🐛 Bug fix
## Checklist
- [x] Verified by extracting the tarball locally
- [x] I have signed off my commits (DCO)