### PR TITLE
feat: add package search with fuzzy name matching and detail page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The platform consists of **4 Go binaries**, an **Angular UI**, and a **ClickHous
 |--------|------|---------|
 | `ingestion-watcher` | K8s CronJob | Scans SBOM/VEX directory, hash-dedup, enqueues jobs |
 | `parsing-worker` | Deployment (N replicas) | Processes SBOMs (SPDX→ClickHouse), VEX files, OSV lookups, license checks |
-| `api-gateway` | Deployment | Stateless REST API (16 endpoints) |
+| `api-gateway` | Deployment | Stateless REST API (19 endpoints) |
 | `cve-refresher` | K8s CronJob (daily) | Checks all known PURLs for newly disclosed CVEs without re-scanning SBOMs |
 
 Key shared packages:
@@ -123,7 +123,7 @@ Frontend Test:   cd ui && npx ng test            # uses Vitest
 - Unit tests use **Vitest** (not Karma/Jasmine). Run via `npx ng test`.
 - Virtual scrolling uses `@angular/cdk` (`ScrollingModule`). Always implement for large lists of dependency nodes or vulnerabilities to prevent browser freezing.
 - Utilize OnPush change detection for data-heavy dashboard components to optimize rendering performance.
-- All routes are lazy-loaded standalone components (see `app.routes.ts`). Feature pages: `dashboard`, `sbom-explorer`, `vulnerability`, `search` (CVE impact, license compliance, dependency stats, version skew), `license-compliance`, `vex`, `archived-packages`.
+- All routes are lazy-loaded standalone components (see `app.routes.ts`). Feature pages: `dashboard`, `sbom-explorer`, `vulnerability`, `search` (CVE impact, license compliance, dependency stats, version skew, package search + detail), `license-compliance`, `vex`, `archived-packages`.
 - Shared chart components live in `shared/charts/` (donut chart, horizontal bar chart).
 - UI supports **Dark Mode** (toggle in navbar, persisted to localStorage) and **Custom CSS Theming** (external `custom-theme.css` mountable without rebuild).
 - UI supports **Site Configuration** (`ui-config.json`): brand name, page title, dashboard texts, and disclaimer are configurable without rebuild. Loaded at startup via `APP_INITIALIZER` in `SiteConfigService`. Mount via Docker volume or Kubernetes ConfigMap (`ui.siteConfig` in Helm values).

--- a/backend/cmd/api-gateway/main.go
+++ b/backend/cmd/api-gateway/main.go
@@ -273,6 +273,43 @@ func main() {
 		writeJSON(w, http.StatusOK, packages)
 	})
 
+	mux.HandleFunc("GET /api/v1/packages/search", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			writeError(w, http.StatusBadRequest, "Missing required query parameter 'q'")
+			return
+		}
+		q = sanitizeLogParam(q)
+		page, _ := strconv.ParseUint(r.URL.Query().Get("page"), 10, 64)
+		pageSize, _ := strconv.ParseUint(r.URL.Query().Get("page_size"), 10, 64)
+		pageSize = clampPageSize(pageSize)
+		result, err := chClient.QueryDependencySearch(r.Context(), q, page, pageSize)
+		if err != nil {
+			log.Printf("ERROR: package search q=%s: %v", sanitizeLogParam(q), err)
+			writeError(w, http.StatusInternalServerError, "Failed to search packages")
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	})
+
+	mux.HandleFunc("GET /api/v1/packages/detail", func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			writeError(w, http.StatusBadRequest, "Missing required query parameter 'name'")
+			return
+		}
+		page, _ := strconv.ParseUint(r.URL.Query().Get("page"), 10, 64)
+		pageSize, _ := strconv.ParseUint(r.URL.Query().Get("page_size"), 10, 64)
+		pageSize = clampPageSize(pageSize)
+		result, err := chClient.QueryPackageDetail(r.Context(), name, page, pageSize)
+		if err != nil {
+			log.Printf("ERROR: package detail name=%s: %v", sanitizeLogParam(name), err)
+			writeError(w, http.StatusInternalServerError, "Failed to fetch package detail")
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	})
+
 	// CORS + security middleware for Angular dev server.
 	handler := securityHeadersMiddleware(
 		rateLimitMiddleware(

--- a/backend/internal/clickhouse/queries_search.go
+++ b/backend/internal/clickhouse/queries_search.go
@@ -717,3 +717,251 @@ func (c *Client) QueryVersionSkew(ctx context.Context, page, pageSize uint64, se
 	}, nil
 }
 
+// QueryDependencySearch searches packages by name (ILIKE fuzzy match) and returns
+// paginated results with project counts and a preview of projects per package.
+func (c *Client) QueryDependencySearch(ctx context.Context, query string, page, pageSize uint64) (*dto.DependencySearchResponse, error) {
+	if pageSize == 0 {
+		pageSize = 20
+	}
+	if page == 0 {
+		page = 1
+	}
+	offset := (page - 1) * pageSize
+	searchPattern := "%" + query + "%"
+
+	var totalResults uint64
+	_ = c.Conn.QueryRow(ctx, `
+		SELECT count() FROM (
+			SELECT dep_name
+			FROM (SELECT * FROM sbom_packages FINAL) AS p
+			ARRAY JOIN p.package_names AS dep_name
+			WHERE dep_name ILIKE ?
+			GROUP BY dep_name
+		)
+	`, searchPattern).Scan(&totalResults)
+
+	rows, err := c.Conn.Query(ctx, `
+		SELECT
+			dep_name,
+			any(dep_purl) AS purl,
+			count(DISTINCT project_key) AS project_count,
+			groupArray(DISTINCT dep_version) AS versions
+		FROM (
+			SELECT
+				dep_name,
+				dep_purl,
+				dep_version,
+				multiIf(
+					position(source_file, 's3://') = 1,
+					arrayStringConcat(
+						arraySlice(splitByChar('/', replaceOne(source_file, 's3://', '')), 2, 2),
+						'/'
+					),
+					doc_name != '',
+					doc_name,
+					source_file
+				) AS project_key
+			FROM (
+				SELECT
+					p.source_file,
+					ifNull(s.document_name, p.source_file) AS doc_name,
+					dep_name,
+					dep_purl,
+					dep_version
+				FROM (SELECT * FROM sbom_packages FINAL) AS p
+				INNER JOIN (SELECT sbom_id, document_name FROM sboms FINAL) AS s
+					ON p.sbom_id = s.sbom_id
+				ARRAY JOIN
+					p.package_names AS dep_name,
+					p.package_purls AS dep_purl,
+					p.package_versions AS dep_version
+			)
+			WHERE dep_name ILIKE ?
+		)
+		GROUP BY dep_name
+		ORDER BY project_count DESC, dep_name ASC
+		LIMIT ? OFFSET ?
+	`, searchPattern, pageSize, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query dependency search: %w", err)
+	}
+	defer rows.Close()
+
+	var items []dto.DependencySearchResult
+	for rows.Next() {
+		var item dto.DependencySearchResult
+		if err := rows.Scan(&item.PackageName, &item.PURL, &item.ProjectCount, &item.Versions); err != nil {
+			return nil, fmt.Errorf("failed to scan search result: %w", err)
+		}
+		items = append(items, item)
+	}
+
+	for i := range items {
+		projRows, err := c.Conn.Query(ctx, `
+			SELECT
+				project_key,
+				any(dep_version) AS version,
+				any(sbom_id) AS sbom_id
+			FROM (
+				SELECT
+					p.sbom_id,
+					dep_version,
+					multiIf(
+						position(p.source_file, 's3://') = 1,
+						arrayStringConcat(
+							arraySlice(splitByChar('/', replaceOne(p.source_file, 's3://', '')), 2, 2),
+							'/'
+						),
+						doc_name != '',
+						doc_name,
+						p.source_file
+					) AS project_key
+				FROM (
+					SELECT
+						p.sbom_id,
+						p.source_file,
+						ifNull(s.document_name, p.source_file) AS doc_name,
+						dep_name,
+						dep_version
+					FROM (SELECT * FROM sbom_packages FINAL) AS p
+					INNER JOIN (SELECT sbom_id, document_name FROM sboms FINAL) AS s
+						ON p.sbom_id = s.sbom_id
+					ARRAY JOIN
+						p.package_names AS dep_name,
+						p.package_versions AS dep_version
+				) AS p
+				WHERE dep_name = ?
+			)
+			GROUP BY project_key
+			ORDER BY project_key ASC
+			LIMIT 5
+		`, items[i].PackageName)
+		if err == nil {
+			for projRows.Next() {
+				var proj dto.DependencySearchProject
+				if err := projRows.Scan(&proj.ProjectName, &proj.Version, &proj.SBOMID); err == nil {
+					items[i].Projects = append(items[i].Projects, proj)
+				}
+			}
+			projRows.Close()
+		}
+		if items[i].Projects == nil {
+			items[i].Projects = []dto.DependencySearchProject{}
+		}
+	}
+
+	if items == nil {
+		items = []dto.DependencySearchResult{}
+	}
+
+	return &dto.DependencySearchResponse{
+		TotalResults: totalResults,
+		Items:        items,
+		Page:         page,
+		PageSize:     pageSize,
+		Query:        query,
+	}, nil
+}
+
+// QueryPackageDetail returns ALL projects using a specific package (paginated).
+func (c *Client) QueryPackageDetail(ctx context.Context, packageName string, page, pageSize uint64) (*dto.PackageDetailResponse, error) {
+	if pageSize == 0 {
+		pageSize = 50
+	}
+	if page == 0 {
+		page = 1
+	}
+	offset := (page - 1) * pageSize
+
+	var totalProjects uint64
+	_ = c.Conn.QueryRow(ctx, `
+		SELECT count(DISTINCT project_key) FROM (
+			SELECT
+				multiIf(
+					position(p.source_file, 's3://') = 1,
+					arrayStringConcat(
+						arraySlice(splitByChar('/', replaceOne(p.source_file, 's3://', '')), 2, 2),
+						'/'
+					),
+					doc_name != '',
+					doc_name,
+					p.source_file
+				) AS project_key
+			FROM (
+				SELECT
+					p.source_file,
+					ifNull(s.document_name, p.source_file) AS doc_name,
+					dep_name
+				FROM (SELECT * FROM sbom_packages FINAL) AS p
+				INNER JOIN (SELECT sbom_id, document_name FROM sboms FINAL) AS s
+					ON p.sbom_id = s.sbom_id
+				ARRAY JOIN p.package_names AS dep_name
+			) AS p
+			WHERE dep_name = ?
+		)
+	`, packageName).Scan(&totalProjects)
+
+	rows, err := c.Conn.Query(ctx, `
+		SELECT
+			project_key,
+			any(dep_version) AS version,
+			any(sbom_id) AS sbom_id
+		FROM (
+			SELECT
+				p.sbom_id,
+				dep_version,
+				multiIf(
+					position(p.source_file, 's3://') = 1,
+					arrayStringConcat(
+						arraySlice(splitByChar('/', replaceOne(p.source_file, 's3://', '')), 2, 2),
+						'/'
+					),
+					doc_name != '',
+					doc_name,
+					p.source_file
+				) AS project_key
+			FROM (
+				SELECT
+					p.sbom_id,
+					p.source_file,
+					ifNull(s.document_name, p.source_file) AS doc_name,
+					dep_name,
+					dep_version
+				FROM (SELECT * FROM sbom_packages FINAL) AS p
+				INNER JOIN (SELECT sbom_id, document_name FROM sboms FINAL) AS s
+					ON p.sbom_id = s.sbom_id
+				ARRAY JOIN
+					p.package_names AS dep_name,
+					p.package_versions AS dep_version
+			) AS p
+			WHERE dep_name = ?
+		)
+		GROUP BY project_key
+		ORDER BY project_key ASC
+		LIMIT ? OFFSET ?
+	`, packageName, pageSize, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query package detail: %w", err)
+	}
+	defer rows.Close()
+
+	var projects []dto.DependencySearchProject
+	for rows.Next() {
+		var proj dto.DependencySearchProject
+		if err := rows.Scan(&proj.ProjectName, &proj.Version, &proj.SBOMID); err != nil {
+			return nil, fmt.Errorf("failed to scan project row: %w", err)
+		}
+		projects = append(projects, proj)
+	}
+	if projects == nil {
+		projects = []dto.DependencySearchProject{}
+	}
+
+	return &dto.PackageDetailResponse{
+		PackageName:   packageName,
+		TotalProjects: totalProjects,
+		Projects:      projects,
+		Page:          page,
+		PageSize:      pageSize,
+	}, nil
+}

--- a/backend/pkg/dto/api.go
+++ b/backend/pkg/dto/api.go
@@ -190,3 +190,37 @@ type VersionSkewResponse struct {
 	PageSize            uint64            `json:"page_size"`
 }
 
+// DependencySearchProject represents a project using a specific package.
+type DependencySearchProject struct {
+	ProjectName string `json:"project_name"`
+	Version     string `json:"version"`
+	SBOMID      string `json:"sbom_id"`
+}
+
+// DependencySearchResult represents a package found by search.
+type DependencySearchResult struct {
+	PackageName  string                    `json:"package_name"`
+	PURL         string                    `json:"purl"`
+	ProjectCount uint64                    `json:"project_count"`
+	Versions     []string                  `json:"versions"`
+	Projects     []DependencySearchProject `json:"projects"`
+}
+
+// DependencySearchResponse wraps the package search response.
+type DependencySearchResponse struct {
+	TotalResults uint64                   `json:"total_results"`
+	Items        []DependencySearchResult `json:"items"`
+	Page         uint64                   `json:"page"`
+	PageSize     uint64                   `json:"page_size"`
+	Query        string                   `json:"query"`
+}
+
+// PackageDetailResponse returns all projects using a specific package (paginated).
+type PackageDetailResponse struct {
+	PackageName   string                    `json:"package_name"`
+	TotalProjects uint64                    `json:"total_projects"`
+	Projects      []DependencySearchProject `json:"projects"`
+	Page          uint64                    `json:"page"`
+	PageSize      uint64                    `json:"page_size"`
+}
+

--- a/docs/ARCHITECTURE_PLAN.md
+++ b/docs/ARCHITECTURE_PLAN.md
@@ -30,7 +30,7 @@ seebom/
 │   ├── cmd/
 │   │   ├── ingestion-watcher/main.go   # K8s CronJob
 │   │   ├── parsing-worker/main.go      # SBOM + VEX processor
-│   │   ├── api-gateway/main.go         # REST API (16 endpoints)
+│   │   ├── api-gateway/main.go         # REST API (19 endpoints)
 │   │   └── cve-refresher/main.go       # Background CVE Refresh CronJob
 │   ├── internal/
 │   │   ├── spdx/              # SPDX JSON streaming parser
@@ -63,7 +63,7 @@ seebom/
 │       │   └── custom-theme.example.css   # Template for custom branding
 │       └── app/
 │           ├── app.ts                 # Navbar + dark-mode toggle
-│           ├── app.routes.ts          # 10 lazy-loaded routes
+│           ├── app.routes.ts          # 13 lazy-loaded routes
 │           ├── core/                  # ApiService, models, HTTP interceptor
 │           ├── shared/charts/         # DonutChart, HorizontalBarChart (themeable)
 │           └── features/
@@ -74,7 +74,10 @@ seebom/
 │               ├── search/
 │               │   ├── cve-impact.component.ts          # CVE → affected projects
 │               │   ├── license-violations.component.ts  # Projects with license issues
-│               │   └── dependency-stats.component.ts    # Top dependencies cross-project
+│               │   ├── dependency-stats.component.ts    # Top dependencies cross-project
+│               │   ├── version-skew.component.ts        # Packages with inconsistent versions
+│               │   ├── package-search.component.ts      # Fuzzy package name search
+│               │   └── package-detail.component.ts      # All projects using a specific package
 │               ├── license-compliance/ # License overview
 │               └── vex/                # VEX statements (with empty state)
 ├── db/
@@ -158,14 +161,14 @@ ClickHouse: sboms, sbom_packages, vulnerabilities, license_compliance, vex_state
        ├── Violations:     sumIf(copyleft|unknown) − exceptions (from config file)
        └── Dep Stats:      ARRAY JOIN + count(DISTINCT sbom_id) cross-project
        ▼
-API Gateway (REST) → 16 Endpoints
+API Gateway (REST) → 19 Endpoints
        │ HTTP/JSON + CORS
        ▼
-Angular UI (11 lazy-loaded routes, virtual scrolling, OnPush, dark mode)
+Angular UI (13 lazy-loaded routes, virtual scrolling, OnPush, dark mode)
        │ Custom CSS theme mountable without Angular rebuild
 ```
 
-## 3. API Endpoints (17)
+## 3. API Endpoints (19)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -186,6 +189,8 @@ Angular UI (11 lazy-loaded routes, virtual scrolling, OnPush, dark mode)
 | GET | `/api/v1/license-policy` | Active license classification (permissive/copyleft lists) |
 | GET | `/api/v1/vex/statements?page=&page_size=` | Paginated VEX statements with matched affected_sboms |
 | GET | `/api/v1/packages/archived` | Packages using archived GitHub repos (no longer maintained) |
+| GET | `/api/v1/packages/search?q=&page=&page_size=` | Fuzzy package name search across all SBOMs (ILIKE, paginated) |
+| GET | `/api/v1/packages/detail?name=&page=&page_size=` | All projects using a specific package (paginated) |
 
 ## 4. ClickHouse Schema (11 Migrations)
 
@@ -214,6 +219,8 @@ Angular UI (11 lazy-loaded routes, virtual scrolling, OnPush, dark mode)
 **License Violations:** `sumIf(package_count, category = 'copyleft')` + `groupArrayArrayIf(non_compliant_packages, ...)` aggregates per SBOM. Exceptions are filtered at query time (no re-ingest needed).
 
 **Dependency Stats:** `ARRAY JOIN package_names, package_purls, package_versions` expands the parallel arrays, then `count(DISTINCT sbom_id)` for cross-project counting.
+
+**Package Search:** `dep_name ILIKE ?` with `ARRAY JOIN` for fuzzy matching. Search results include project count, versions, and a preview of 5 projects. Detail endpoint returns all projects paginated via `GROUP BY project_key ORDER BY project_key LIMIT ? OFFSET ?`.
 
 ## 5. VEX Architecture
 
@@ -258,6 +265,9 @@ Moved to Section 10 for comprehensive coverage including exemptions and visual r
 | `/licenses` | LicenseOverviewComponent | Category cards + virtual scroll |
 | `/license-compliance` | LicenseViolationsComponent | **2 tabs:** Violations (filtered by exceptions), active exceptions |
 | `/dependencies` | DependencyStatsComponent | Top-100 dependencies, version pills, vuln count, unique deps counter |
+| `/package-search` | PackageSearchComponent | Fuzzy package name search, expandable results with project preview, link to detail |
+| `/package-search/:name` | PackageDetailComponent | All projects using a specific package (paginated table with SBOM links) |
+| `/version-skew` | VersionSkewComponent | Packages with inconsistent versions across projects (paginated, searchable) |
 | `/vex` | VEXListComponent | Virtual scroll, status badges, justification, empty state |
 | `/archived-packages` | ArchivedPackagesComponent | Grouped by repo, project aggregation with version tags, stars, last push |
 
@@ -374,3 +384,4 @@ Moved to Section 10 for comprehensive coverage including exemptions and visual r
 | 28 | SBOM detail: Archived badge on dependencies from archived repos | ✅ Implemented |
 | 29 | Go temp package name sanitization: `tmp.xxxxx` CI/CD artifacts replaced in SPDX parser with PURL-based names and filtered in license checker as fallback | ✅ Implemented |
 | 30 | S3 bucket ingestion: Multi-bucket S3 support as default ingestion method via `minio-go/v7`. Streaming ListObjects with batched enqueue (500/batch). Worker fetches via `s3://` URIs. Local filesystem ingestion preserved. | ✅ Implemented |
+| 31 | Package search: Fuzzy ILIKE search on package names with detail page showing all projects using a package (paginated). Search preview shows first 5 projects; detail page shows all. | ✅ Implemented |

--- a/docs/content/docs/architecture/_index.md
+++ b/docs/content/docs/architecture/_index.md
@@ -21,7 +21,7 @@ Kubernetes-native SBOM platform as a monorepo. Go backend with four binaries (Cr
 |--------|------|---------|
 | `ingestion-watcher` | K8s CronJob | Scans SBOM/VEX directory, hash-dedup, enqueues jobs |
 | `parsing-worker` | Deployment (N replicas) | Processes SBOMs (SPDX→ClickHouse), VEX files, OSV lookups, license resolution, compliance checks |
-| `api-gateway` | Deployment | Stateless REST API (16 endpoints) |
+| `api-gateway` | Deployment | Stateless REST API (19 endpoints) |
 | `cve-refresher` | K8s CronJob (daily) | Checks all known PURLs for newly disclosed CVEs |
 
 ## Data Flow
@@ -63,7 +63,7 @@ ClickHouse: sboms, sbom_packages, vulnerabilities, license_compliance, vex_state
        │         │  Dedup + reverse-lookup + INSERT  │
        │         └──────────────────────────────────┘
        ▼
-API Gateway (REST) → 16 Endpoints → Angular UI
+API Gateway (REST) → 19 Endpoints → Angular UI
 ```
 
 ## ClickHouse Schema
@@ -101,6 +101,9 @@ API Gateway (REST) → 16 Endpoints → Angular UI
 | GET | `/api/v1/license-policy` | Active license policy |
 | GET | `/api/v1/vex/statements?page=&page_size=` | Paginated VEX statements |
 | GET | `/api/v1/packages/archived` | Archived GitHub repo packages |
+| GET | `/api/v1/packages/search?q=&page=&page_size=` | Fuzzy package name search |
+| GET | `/api/v1/packages/detail?name=&page=&page_size=` | All projects using a specific package |
+| GET | `/api/v1/stats/version-skew?page=&page_size=&search=` | Version skew detection |
 
 ## VEX Architecture
 
@@ -159,5 +162,5 @@ License resolution runs **before** the ClickHouse insert so that `sbom_packages.
 
 ## Angular UI
 
-10 lazy-loaded routes with virtual scrolling, OnPush change detection, dark mode toggle, and CSS custom properties theming. External `custom-theme.css` and `ui-config.json` are mountable without rebuild.
+13 lazy-loaded routes with virtual scrolling, OnPush change detection, dark mode toggle, and CSS custom properties theming. Includes package search with fuzzy name matching and paginated detail views. External `custom-theme.css` and `ui-config.json` are mountable without rebuild.
 

--- a/docs/content/docs/development/testing.md
+++ b/docs/content/docs/development/testing.md
@@ -149,3 +149,40 @@ Tests run automatically on every push/PR:
   run: go test ./... -count=1 -race
 ```
 
+## Angular (Frontend) Tests
+
+The Angular frontend uses **Vitest** (not Karma/Jasmine). Tests live alongside components as `*.spec.ts` files.
+
+### Quick Start
+
+```bash
+cd ui
+
+# Run all tests
+npx ng test
+
+# Run once (no watch)
+npx ng test --watch=false
+```
+
+### Current Test Inventory (Frontend)
+
+| Spec File | Tests | What's Covered |
+|-----------|-------|---------------|
+| `app.spec.ts` | 3 | App creation, navbar brand, navigation links (10 routes) |
+| `dashboard.component.spec.ts` | 2 | Component creation, KPI rendering |
+| `sbom-detail.component.spec.ts` | 4 | Tab switching, vuln/license/dep views |
+| `cve-impact.component.spec.ts` | 2 | CVE search, project listing |
+| `license-violations.component.spec.ts` | 2 | Violations tab, exceptions tab |
+| `dependency-stats.component.spec.ts` | 2 | Top dependencies, unique deps counter |
+| `version-skew.spec.ts` | 3 | Model parsing, empty results, sorting |
+| `package-search.spec.ts` | 8 | Search/detail response parsing, pagination, URL encoding, sorting |
+| plus more... | — | Various model and component tests |
+| **Total** | **53** | |
+
+### Test Patterns (Angular)
+
+- **Model tests** — Verify TypeScript interfaces match API shapes (no HTTP mocking needed)
+- **Component tests** — Use `TestBed` with `provideHttpClientTesting()` for HTTP mocking
+- **OnPush strategy** — Tests call `fixture.detectChanges()` and verify DOM output
+

--- a/ui/src/app/app.routes.ts
+++ b/ui/src/app/app.routes.ts
@@ -50,6 +50,20 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'package-search',
+    loadComponent: () =>
+      import('./features/search/package-search.component').then(
+        (m) => m.PackageSearchComponent
+      ),
+  },
+  {
+    path: 'package-search/:name',
+    loadComponent: () =>
+      import('./features/search/package-detail.component').then(
+        (m) => m.PackageDetailComponent
+      ),
+  },
+  {
     path: 'version-skew',
     loadComponent: () =>
       import('./features/search/version-skew.component').then(

--- a/ui/src/app/app.spec.ts
+++ b/ui/src/app/app.spec.ts
@@ -42,7 +42,7 @@ describe('App', () => {
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     const links = compiled.querySelectorAll('.nav-links a');
-    expect(links.length).toBe(8);
+    expect(links.length).toBe(10);
     expect(links[0].textContent).toContain('Dashboard');
     expect(links[1].textContent).toContain('SBOMs');
     expect(links[2].textContent).toContain('Vulnerabilities');
@@ -50,7 +50,9 @@ describe('App', () => {
     expect(links[4].textContent).toContain('Licenses');
     expect(links[5].textContent).toContain('Compliance');
     expect(links[6].textContent).toContain('Dependencies');
-    expect(links[7].textContent).toContain('VEX');
+    expect(links[7].textContent).toContain('Pkg Search');
+    expect(links[8].textContent).toContain('Version Skew');
+    expect(links[9].textContent).toContain('VEX');
   });
 });
 

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -20,6 +20,7 @@ import { SiteConfigService } from './core/site-config.service';
         <a routerLink="/licenses" routerLinkActive="active">Licenses</a>
         <a routerLink="/license-compliance" routerLinkActive="active">Compliance</a>
         <a routerLink="/dependencies" routerLinkActive="active">Dependencies</a>
+        <a routerLink="/package-search" routerLinkActive="active">Pkg Search</a>
         <a routerLink="/version-skew" routerLinkActive="active">Version Skew</a>
         <a routerLink="/vex" routerLinkActive="active">VEX</a>
       </div>

--- a/ui/src/app/core/api.models.ts
+++ b/ui/src/app/core/api.models.ts
@@ -211,3 +211,32 @@ export interface LicenseException {
   comment?: string;
 }
 
+export interface DependencySearchProject {
+  project_name: string;
+  version: string;
+  sbom_id: string;
+}
+
+export interface DependencySearchResult {
+  package_name: string;
+  purl: string;
+  project_count: number;
+  versions: string[];
+  projects: DependencySearchProject[];
+}
+
+export interface DependencySearchResponse {
+  total_results: number;
+  items: DependencySearchResult[];
+  page: number;
+  page_size: number;
+  query: string;
+}
+
+export interface PackageDetailResponse {
+  package_name: string;
+  total_projects: number;
+  projects: DependencySearchProject[];
+  page: number;
+  page_size: number;
+}

--- a/ui/src/app/core/api.service.ts
+++ b/ui/src/app/core/api.service.ts
@@ -14,6 +14,8 @@ import {
   ProjectLicenseViolation,
   AffectedProject,
   DependencyStatsResponse,
+  DependencySearchResponse,
+  PackageDetailResponse,
   VersionSkewResponse,
   LicenseExceptionsFile,
   ArchivedPackageInfo,
@@ -110,6 +112,22 @@ export class ApiService {
 
   getArchivedPackages(): Observable<ArchivedPackageInfo[]> {
     return this.http.get<ArchivedPackageInfo[]>(`${this.baseUrl}/packages/archived`);
+  }
+
+  searchPackages(query: string, page = 1, pageSize = 50): Observable<DependencySearchResponse> {
+    let params = new HttpParams()
+      .set('q', query)
+      .set('page', page.toString())
+      .set('page_size', pageSize.toString());
+    return this.http.get<DependencySearchResponse>(`${this.baseUrl}/packages/search`, { params });
+  }
+
+  getPackageDetail(name: string, page = 1, pageSize = 50): Observable<PackageDetailResponse> {
+    const params = new HttpParams()
+      .set('name', name)
+      .set('page', page.toString())
+      .set('page_size', pageSize.toString());
+    return this.http.get<PackageDetailResponse>(`${this.baseUrl}/packages/detail`, { params });
   }
 }
 

--- a/ui/src/app/features/search/package-detail.component.ts
+++ b/ui/src/app/features/search/package-detail.component.ts
@@ -1,0 +1,191 @@
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ApiService } from '../../core/api.service';
+import { PackageDetailResponse } from '../../core/api.models';
+
+@Component({
+  selector: 'app-package-detail',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="detail-page">
+      <div class="breadcrumb">
+        <a routerLink="/package-search" class="back-link">← Package Search</a>
+      </div>
+
+      <h1>{{ packageName }}</h1>
+      <p class="subtitle" *ngIf="data">
+        Used in <strong>{{ data.total_projects }}</strong>
+        {{ data.total_projects === 1 ? 'project' : 'projects' }}
+      </p>
+
+      <div class="loading" *ngIf="loading">Loading projects...</div>
+
+      <div class="projects-table" *ngIf="data && data.projects.length > 0">
+        <div class="table-header">
+          <span class="col-project">Project</span>
+          <span class="col-version">Version</span>
+        </div>
+        <div class="table-row" *ngFor="let proj of data.projects">
+          <a [routerLink]="['/sboms', proj.sbom_id]" class="col-project project-link">{{ proj.project_name }}</a>
+          <span class="col-version version-mono">{{ proj.version }}</span>
+        </div>
+      </div>
+
+      <div class="empty-state" *ngIf="data && data.projects.length === 0">
+        <p>No projects found using this package.</p>
+      </div>
+
+      <div class="pagination" *ngIf="data && data.total_projects > data.page_size">
+        <button (click)="goToPage(currentPage - 1)" [disabled]="currentPage <= 1">← Previous</button>
+        <span>Page {{ currentPage }} of {{ totalPages }}</span>
+        <button (click)="goToPage(currentPage + 1)" [disabled]="currentPage >= totalPages">Next →</button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .detail-page { padding: 32px; max-width: 900px; margin: 0 auto; }
+    .breadcrumb { margin-bottom: 16px; }
+    .back-link {
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.85rem;
+    }
+    .back-link:hover { text-decoration: underline; }
+
+    h1 {
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: var(--text);
+      margin: 0 0 4px;
+      word-break: break-all;
+      font-family: monospace;
+    }
+    .subtitle { color: var(--text-secondary); font-size: 0.85rem; margin: 0 0 24px; }
+
+    .projects-table {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .table-header {
+      display: flex;
+      padding: 10px 16px;
+      background: var(--table-header-bg, #f8f9fa);
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .table-row {
+      display: flex;
+      padding: 10px 16px;
+      border-top: 1px solid var(--border);
+      align-items: center;
+      font-size: 0.85rem;
+    }
+    .table-row:hover { background: var(--row-hover-bg, #f8f9fa); }
+
+    .col-project { flex: 1; }
+    .col-version { width: 180px; text-align: right; }
+
+    .project-link {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .project-link:hover { text-decoration: underline; }
+    .version-mono {
+      font-family: monospace;
+      font-size: 0.8rem;
+      color: var(--text-muted);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 48px 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+    .loading {
+      text-align: center;
+      padding: 24px;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+    }
+
+    .pagination {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      margin-top: 24px;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+    .pagination button {
+      padding: 6px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--card-bg);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+    .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .pagination button:not(:disabled):hover { border-color: var(--accent); }
+  `]
+})
+export class PackageDetailComponent implements OnInit {
+  packageName = '';
+  data: PackageDetailResponse | null = null;
+  loading = false;
+  currentPage = 1;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly api: ApiService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe(params => {
+      this.packageName = decodeURIComponent(params.get('name') || '');
+      this.currentPage = 1;
+      this.loadData();
+    });
+  }
+
+  get totalPages(): number {
+    if (!this.data) return 1;
+    return Math.ceil(this.data.total_projects / this.data.page_size);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.currentPage = page;
+    this.loadData();
+  }
+
+  private loadData(): void {
+    if (!this.packageName) return;
+    this.loading = true;
+    this.cdr.markForCheck();
+
+    this.api.getPackageDetail(this.packageName, this.currentPage, 50).subscribe({
+      next: (resp) => {
+        this.data = resp;
+        this.loading = false;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.loading = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+}
+

--- a/ui/src/app/features/search/package-search.component.ts
+++ b/ui/src/app/features/search/package-search.component.ts
@@ -1,0 +1,290 @@
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { ApiService } from '../../core/api.service';
+import { DependencySearchResponse, DependencySearchResult } from '../../core/api.models';
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-package-search',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="search-page">
+      <h1>Package Search</h1>
+      <p class="subtitle">Search for a dependency by name and see which projects use it.</p>
+
+      <div class="search-bar">
+        <input
+          type="text"
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="onSearchChange($event)"
+          placeholder="Search package name (e.g. golang.org/x/net, lodash, react)..."
+          class="search-input"
+          autofocus
+        />
+      </div>
+
+      <div class="results-summary" *ngIf="data && searchQuery">
+        <span class="result-count">{{ data.total_results | number }} packages found</span>
+        <span class="page-info" *ngIf="data.total_results > data.page_size">
+          Page {{ data.page }} of {{ totalPages }}
+        </span>
+      </div>
+
+      <div class="results" *ngIf="data && data.items.length > 0">
+        <div class="result-card" *ngFor="let item of data.items" (click)="toggleExpand(item)">
+          <div class="result-header">
+            <div class="pkg-info">
+              <span class="pkg-name">{{ item.package_name }}</span>
+              <span class="pkg-meta">
+                {{ item.project_count }} {{ item.project_count === 1 ? 'project' : 'projects' }}
+                · {{ item.versions.length }} {{ item.versions.length === 1 ? 'version' : 'versions' }}
+              </span>
+            </div>
+            <span class="expand-icon">{{ expandedPkg === item.package_name ? '▾' : '▸' }}</span>
+          </div>
+
+          <div class="version-tags" *ngIf="item.versions.length > 0">
+            <span class="version-tag" *ngFor="let v of item.versions.slice(0, 8)">{{ v }}</span>
+            <span class="version-tag more" *ngIf="item.versions.length > 8">+{{ item.versions.length - 8 }}</span>
+          </div>
+
+          <div class="projects-list" *ngIf="expandedPkg === item.package_name && item.projects.length > 0">
+            <div class="project-row" *ngFor="let proj of item.projects">
+              <a [routerLink]="['/sboms', proj.sbom_id]" class="project-link">{{ proj.project_name }}</a>
+              <span class="project-version">{{ proj.version }}</span>
+            </div>
+            <a *ngIf="item.project_count > 5"
+               [routerLink]="['/package-search', encodePackageName(item.package_name)]"
+               class="view-all-link">
+              View all {{ item.project_count }} projects →
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <div class="empty-state" *ngIf="data && data.items.length === 0 && searchQuery">
+        <p>No packages found matching "{{ searchQuery }}"</p>
+      </div>
+
+      <div class="empty-state" *ngIf="!data && !loading && !searchQuery">
+        <p>Start typing to search for packages across all projects.</p>
+      </div>
+
+      <div class="loading" *ngIf="loading">Searching...</div>
+
+      <div class="pagination" *ngIf="data && data.total_results > data.page_size">
+        <button (click)="goToPage(currentPage - 1)" [disabled]="currentPage <= 1">← Previous</button>
+        <span>Page {{ currentPage }} of {{ totalPages }}</span>
+        <button (click)="goToPage(currentPage + 1)" [disabled]="currentPage >= totalPages">Next →</button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .search-page { padding: 32px; max-width: 900px; margin: 0 auto; }
+    h1 { font-size: 1.5rem; font-weight: 700; color: var(--text); margin: 0 0 4px; }
+    .subtitle { color: var(--text-secondary); font-size: 0.85rem; margin: 0 0 24px; }
+
+    .search-bar { margin-bottom: 20px; }
+    .search-input {
+      width: 100%;
+      padding: 12px 16px;
+      font-size: 0.95rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--card-bg);
+      color: var(--text);
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    .search-input:focus { border-color: var(--accent); }
+    .search-input::placeholder { color: var(--text-muted); }
+
+    .results-summary {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+    .result-count { font-weight: 600; }
+
+    .result-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 12px;
+      cursor: pointer;
+      transition: border-color 0.15s;
+    }
+    .result-card:hover { border-color: var(--accent); }
+
+    .result-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .pkg-info { display: flex; flex-direction: column; gap: 4px; }
+    .pkg-name { font-weight: 600; font-size: 0.9rem; color: var(--text); }
+    .pkg-meta { font-size: 0.75rem; color: var(--text-secondary); }
+    .expand-icon { color: var(--text-muted); font-size: 0.9rem; }
+
+    .version-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+    .version-tag {
+      background: var(--tag-bg, #f0f0f0);
+      color: var(--text-secondary);
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-family: monospace;
+    }
+    .version-tag.more { font-style: italic; }
+
+    .projects-list {
+      margin-top: 12px;
+      border-top: 1px solid var(--border);
+      padding-top: 12px;
+    }
+    .project-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 6px 0;
+      font-size: 0.8rem;
+    }
+    .project-link {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .project-link:hover { text-decoration: underline; }
+    .project-version {
+      font-family: monospace;
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+    .view-all-link {
+      display: block;
+      margin-top: 10px;
+      padding-top: 8px;
+      border-top: 1px dashed var(--border);
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.8rem;
+      font-weight: 500;
+    }
+    .view-all-link:hover { text-decoration: underline; }
+
+    .empty-state {
+      text-align: center;
+      padding: 48px 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+    .loading {
+      text-align: center;
+      padding: 24px;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+    }
+
+    .pagination {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      margin-top: 24px;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+    .pagination button {
+      padding: 6px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--card-bg);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+    .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .pagination button:not(:disabled):hover { border-color: var(--accent); }
+  `]
+})
+export class PackageSearchComponent implements OnInit {
+  searchQuery = '';
+  data: DependencySearchResponse | null = null;
+  loading = false;
+  expandedPkg: string | null = null;
+  currentPage = 1;
+
+  private searchSubject = new Subject<string>();
+
+  constructor(
+    private readonly api: ApiService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.searchSubject.pipe(
+      debounceTime(300),
+      distinctUntilChanged()
+    ).subscribe(query => {
+      this.currentPage = 1;
+      this.doSearch(query);
+    });
+  }
+
+  onSearchChange(value: string): void {
+    this.searchSubject.next(value);
+  }
+
+  get totalPages(): number {
+    if (!this.data) return 1;
+    return Math.ceil(this.data.total_results / this.data.page_size);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.currentPage = page;
+    this.doSearch(this.searchQuery);
+  }
+
+  toggleExpand(item: DependencySearchResult): void {
+    this.expandedPkg = this.expandedPkg === item.package_name ? null : item.package_name;
+  }
+
+  encodePackageName(name: string): string {
+    return encodeURIComponent(name);
+  }
+
+  private doSearch(query: string): void {
+    if (!query || query.length < 2) {
+      this.data = null;
+      this.loading = false;
+      this.cdr.markForCheck();
+      return;
+    }
+    this.loading = true;
+    this.cdr.markForCheck();
+
+    this.api.searchPackages(query, this.currentPage, 20).subscribe({
+      next: (resp) => {
+        this.data = resp;
+        this.loading = false;
+        this.expandedPkg = null;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.loading = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+}
+

--- a/ui/src/app/features/search/package-search.spec.ts
+++ b/ui/src/app/features/search/package-search.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DependencySearchResponse,
+  DependencySearchResult,
+  DependencySearchProject,
+  PackageDetailResponse,
+} from '../../core/api.models';
+
+describe('PackageSearch Models', () => {
+  it('should parse a search response with results', () => {
+    const response: DependencySearchResponse = {
+      total_results: 3,
+      page: 1,
+      page_size: 20,
+      query: 'golang.org/x/net',
+      items: [
+        {
+          package_name: 'golang.org/x/net',
+          purl: 'pkg:golang/golang.org/x/net@v0.17.0',
+          project_count: 12,
+          versions: ['v0.17.0', 'v0.21.0', 'v0.25.0'],
+          projects: [
+            { project_name: 'etcd-io/raft', version: 'v0.17.0', sbom_id: 'abc-123' },
+            { project_name: 'kubernetes/kubernetes', version: 'v0.21.0', sbom_id: 'def-456' },
+          ],
+        },
+      ],
+    };
+
+    expect(response.total_results).toBe(3);
+    expect(response.query).toBe('golang.org/x/net');
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].package_name).toBe('golang.org/x/net');
+    expect(response.items[0].project_count).toBe(12);
+    expect(response.items[0].versions).toHaveLength(3);
+    expect(response.items[0].projects).toHaveLength(2);
+    expect(response.items[0].projects[0].project_name).toBe('etcd-io/raft');
+  });
+
+  it('should handle empty search results', () => {
+    const response: DependencySearchResponse = {
+      total_results: 0,
+      page: 1,
+      page_size: 20,
+      query: 'nonexistent-pkg',
+      items: [],
+    };
+
+    expect(response.total_results).toBe(0);
+    expect(response.items).toHaveLength(0);
+  });
+
+  it('should calculate total pages correctly', () => {
+    const response: DependencySearchResponse = {
+      total_results: 47,
+      page: 1,
+      page_size: 20,
+      query: 'net',
+      items: [],
+    };
+
+    const totalPages = Math.ceil(response.total_results / response.page_size);
+    expect(totalPages).toBe(3);
+  });
+
+  it('should parse a package detail response', () => {
+    const detail: PackageDetailResponse = {
+      package_name: 'golang.org/x/net',
+      total_projects: 42,
+      page: 1,
+      page_size: 50,
+      projects: [
+        { project_name: 'etcd-io/raft', version: 'v0.17.0', sbom_id: 'abc-123' },
+        { project_name: 'kubernetes/kubernetes', version: 'v0.21.0', sbom_id: 'def-456' },
+        { project_name: 'prometheus/prometheus', version: 'v0.25.0', sbom_id: 'ghi-789' },
+      ],
+    };
+
+    expect(detail.package_name).toBe('golang.org/x/net');
+    expect(detail.total_projects).toBe(42);
+    expect(detail.projects).toHaveLength(3);
+    expect(detail.projects[2].project_name).toBe('prometheus/prometheus');
+  });
+
+  it('should handle package detail with no projects', () => {
+    const detail: PackageDetailResponse = {
+      package_name: 'some-unused-package',
+      total_projects: 0,
+      page: 1,
+      page_size: 50,
+      projects: [],
+    };
+
+    expect(detail.total_projects).toBe(0);
+    expect(detail.projects).toHaveLength(0);
+  });
+
+  it('should support pagination in detail response', () => {
+    const detail: PackageDetailResponse = {
+      package_name: 'lodash',
+      total_projects: 120,
+      page: 3,
+      page_size: 50,
+      projects: Array.from({ length: 20 }, (_, i) => ({
+        project_name: `project-${i}`,
+        version: `1.0.${i}`,
+        sbom_id: `id-${i}`,
+      })),
+    };
+
+    const totalPages = Math.ceil(detail.total_projects / detail.page_size);
+    expect(totalPages).toBe(3);
+    expect(detail.page).toBe(3);
+    expect(detail.projects).toHaveLength(20);
+  });
+
+  it('should encode package names with slashes for URL routing', () => {
+    const packageName = 'golang.org/x/net';
+    const encoded = encodeURIComponent(packageName);
+    expect(encoded).toBe('golang.org%2Fx%2Fnet');
+    expect(decodeURIComponent(encoded)).toBe(packageName);
+  });
+
+  it('should sort search results by project count descending', () => {
+    const items: DependencySearchResult[] = [
+      { package_name: 'a', purl: '', project_count: 5, versions: [], projects: [] },
+      { package_name: 'b', purl: '', project_count: 20, versions: [], projects: [] },
+      { package_name: 'c', purl: '', project_count: 12, versions: [], projects: [] },
+    ];
+
+    const sorted = [...items].sort((a, b) => b.project_count - a.project_count);
+    expect(sorted[0].package_name).toBe('b');
+    expect(sorted[1].package_name).toBe('c');
+    expect(sorted[2].package_name).toBe('a');
+  });
+});
+


### PR DESCRIPTION
## Summary
Add fuzzy package name search across all SBOMs and a detail page showing all projects that use a specific package (paginated).
Closes #37
## Changes
### Backend (2 new endpoints → 19 total)
- `GET /api/v1/packages/search?q=&page=&page_size=` — ILIKE fuzzy search on package names, paginated, returns project count + version list + first 5 projects preview
- `GET /api/v1/packages/detail?name=&page=&page_size=` — All projects using a specific package, paginated with SBOM links
- DTOs: `DependencySearchResponse`, `DependencySearchResult`, `DependencySearchProject`, `PackageDetailResponse`
- ClickHouse queries: `QueryDependencySearch`, `QueryPackageDetail` (ARRAY JOIN + ILIKE + project_key derivation)
### Frontend (2 new routes → 13 total)
- `/package-search` — Search page with debounced input, expandable result cards (first 5 projects inline), "View all N projects →" link
- `/package-search/:name` — Detail page with paginated table of ALL projects + SBOM detail links
- Nav link "Pkg Search" between Dependencies and Version Skew
- 8 new Vitest tests (models, pagination, URL encoding, sorting)
### Documentation
- **AGENTS.md**: endpoint count → 19, feature pages list updated
- **ARCHITECTURE_PLAN.md**: API table (2 new), UI routes table (3 new), Key Queries section, Decision Log #31
- **Hugo docs** (`architecture/_index.md`): endpoint count + 3 new endpoints in API table
- **Hugo docs** (`development/testing.md`): New Angular/Vitest test section with inventory table
## How to test
1. `make dev` (or `make ch-only && make api && make worker && make ingest && make ui-dev`)
2. Navigate to **Pkg Search** in the navbar
3. Search for e.g. `golang.org/x/net`
4. Expand a result to see first 5 projects
5. Click "View all N projects →" to see the paginated detail page
6. Click a project name to navigate to its SBOM detail
## Checklist
- [x] Go builds (`go build ./...`)
- [x] Go vet (`go vet ./...`)
- [x] Go tests pass (`go test ./... -count=1`)
- [x] Angular builds (`npx ng build --configuration=production`)
- [x] Angular tests pass (`npx ng test --watch=false`) — 14 files, 53 tests
- [x] No new dependencies added
- [x] No schema migration needed (queries existing `sbom_packages` table)
- [x] ARCHITECTURE_PLAN.md updated
- [x] AGENTS.md updated
- [x] Hugo docs updated
- [x] Commit is signed