### PR TITLE
fix(ci): use cosign v4 --bundle format for release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,7 @@ jobs:
       - name: Sign release artifacts
         run: |
           cosign sign-blob --yes \
-            --output-signature seebom-${{ steps.version.outputs.version }}.spdx.json.sig \
-            --output-certificate seebom-${{ steps.version.outputs.version }}.spdx.json.pem \
+            --bundle seebom-${{ steps.version.outputs.version }}.spdx.json.bundle \
             seebom-${{ steps.version.outputs.version }}.spdx.json
 
       - name: Attest SBOM provenance
@@ -166,8 +165,7 @@ jobs:
           generate_release_notes: true
           files: |
             seebom-${{ steps.version.outputs.version }}.spdx.json
-            seebom-${{ steps.version.outputs.version }}.spdx.json.sig
-            seebom-${{ steps.version.outputs.version }}.spdx.json.pem
+            seebom-${{ steps.version.outputs.version }}.spdx.json.bundle
             seebom-${{ steps.version.outputs.version }}.spdx.json.intoto.jsonl
           body: |
             ## Container Images


### PR DESCRIPTION
## Problem
The v0.4.0 release workflow failed at the `Sign release artifacts` step:
```
Error: signing seebom-0.4.0.spdx.json: create bundle file: open : no such file or directory
```
**Root cause:** `sigstore/cosign-installer` was bumped from v3.8.2 to v4.1.2 in #127. cosign v4 deprecated `--output-signature` and `--output-certificate` in favor of `--bundle`. The old flags are silently ignored, causing the sign step to fail.
## Fix
- `cosign sign-blob`: Replace `--output-signature` + `--output-certificate` with `--bundle`
- Release files: Replace `.sig` + `.pem` attachments with single `.bundle` file
- Provenance attestation (`.intoto.jsonl`) unchanged
## After merge
Delete the broken v0.4.0 release, re-tag, and re-release.