### PR TITLE
Make batch job cleanup optional for argocd

### DIFF
--- a/deploy/helm/seebom/templates/job-migrate.yaml
+++ b/deploy/helm/seebom/templates/job-migrate.yaml
@@ -7,7 +7,9 @@ metadata:
     app.kubernetes.io/component: migrate
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
+  {{- if .Values.cleanBatchJobs }}
   ttlSecondsAfterFinished: 300
+  {{- end }}
   backoffLimit: 10
   template:
     metadata:

--- a/deploy/helm/seebom/templates/job-seed-sboms.yaml
+++ b/deploy/helm/seebom/templates/job-seed-sboms.yaml
@@ -8,7 +8,9 @@ metadata:
     app.kubernetes.io/component: seed-sboms
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
+  {{- if .Values.cleanBatchJobs }}
   ttlSecondsAfterFinished: 300
+  {{- end }}
   backoffLimit: 3
   template:
     metadata:

--- a/deploy/helm/seebom/values.yaml
+++ b/deploy/helm/seebom/values.yaml
@@ -186,3 +186,5 @@ seedJob:
   # Set to download CNCF license exceptions into the SBOM PVC:
   # cncfExceptionsURL: "https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json"
 
+# Set to false to keep Job resources after completion (for debugging, or better visibility in ArgoCD). By default, Jobs are cleaned up after 5 minutes to prevent clutter.
+cleanBatchJobs: true


### PR DESCRIPTION
## Description

This PR updates the Helm chart to make `ttlSecondsAfterFinished` optional. When the jobs are garbage-collected automatically, ArgoCD creates them again in the self-heal mode.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🏗️ Infrastructure / CI / Helm

## Component(s) Affected

- [ ] API Gateway
- [ ] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [x] Helm Chart
- [ ] Documentation

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## How Has This Been Tested?

<!-- Describe the tests that you ran. -->

- [ ] `go test ./...` passes
- [ ] `ng build` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [x] Manual testing on Kubernetes

## Checklist

- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [ ] New and existing unit tests pass locally
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes. -->

