### PR TITLE
docs: add API reference, release checklist, and major version policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,9 +131,15 @@ Frontend Test:   cd ui && npx ng test            # uses Vitest
 - Project grouping with clickable version tags is used in CVE Impact, VEX, and License Overview pages.
 
 # Boundaries
-- **Always do:** Write unit tests for new Go packages and Angular components. Ensure ClickHouse bulk inserts are batched. Update `docs/ARCHITECTURE_PLAN.md` when adding new services or features. **Before any release tag:** run `govulncheck ./...` (backend), `npm audit` (ui + docs), fix all vulnerabilities, and verify the build passes. Scan all three ecosystems (Go, Angular npm, Hugo docs npm).
+- **Always do:** Write unit tests for new Go packages and Angular components. Ensure ClickHouse bulk inserts are batched. Update `docs/ARCHITECTURE_PLAN.md` when adding new services or features. **Before any minor/major release tag:** run `govulncheck ./...` (backend), `npm audit` (ui + docs), fix all vulnerabilities, and verify the build passes. Scan all three ecosystems (Go, Angular npm, Hugo docs npm). **Update `ROADMAP.md`** when cutting a minor release — mark completed items as done, adjust phase timelines, and ensure the dependency graph is current.
 - **Ask first:** Before adding new third-party dependencies (npm or Go modules), modifying the ClickHouse schema, changing Kubernetes manifest structures, or creating/merging pull requests.
-- **Never do:** Never commit secrets or API keys. Never use a relational database (like PostgreSQL) for the core SBOM dependency trees. Never split the codebase into multiple repositories. Never add write APIs for license exceptions (frontend is public). Never use `bypassSecurityTrustHtml` in Angular — use `sanitizer.sanitize(SecurityContext.HTML, ...)` instead. Never invent or guess SHA hashes for pinned GitHub Actions — always verify against the GitHub API. Never push changes to upstream without explicit approval.
+- **Never do:** Never commit secrets or API keys. Never use a relational database (like PostgreSQL) for the core SBOM dependency trees. Never split the codebase into multiple repositories. Never add write APIs for license exceptions (frontend is public). Never use `bypassSecurityTrustHtml` in Angular — use `sanitizer.sanitize(SecurityContext.HTML, ...)` instead. Never invent or guess SHA hashes for pinned GitHub Actions — always verify against the GitHub API. Never push changes to upstream without explicit approval. Never bump the major version without a migration guide and 3-month advance notice via roadmap.
+
+# Major Version Policy
+- Major bumps happen every **2–3 years**, driven by accumulated breaking changes (schema, API, Helm values), not by calendar.
+- Previous major receives security patches for 12 months after new major GA.
+- A migration guide with automated tooling (schema scripts, Helm values converter) is mandatory before tagging.
+- Projected: v1.0 October 2026, v2.0 earliest Q1/Q2 2028.
 
 # Security Hardening
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,15 @@
 
 Thank you for your interest in contributing to SeeBOM! We welcome contributions from everyone.
 
+> 📖 **Full documentation:** [docs.seebom.dev](https://docs.seebom.dev/)  
+> 🪜 **Contributor Ladder:** [docs.seebom.dev/docs/development/contributor-ladder/](https://docs.seebom.dev/docs/development/contributor-ladder/)  
+> 🤖 **AI Usage Policy:** [docs.seebom.dev/docs/development/ai-policy/](https://docs.seebom.dev/docs/development/ai-policy/)  
+> 🗺️ **Roadmap:** [docs.seebom.dev/docs/roadmap/](https://docs.seebom.dev/docs/roadmap/)
+
 ## Getting Started
 
 1. **Fork** the repository and clone your fork
-2. Set up the development environment (see [Getting Started](https://seebom.cncf.io/docs/getting-started/))
+2. Set up the development environment (see [Getting Started](https://docs.seebom.dev/docs/getting-started/))
 3. Create a feature branch from `main`
 4. Make your changes
 5. Submit a pull request
@@ -24,7 +29,7 @@ make worker   # Terminal 3
 make ui-dev   # Terminal 4
 ```
 
-See the [Development Guide](https://seebom.cncf.io/docs/development/) for details.
+See the [Development Guide](https://docs.seebom.dev/docs/development/) for details.
 
 ## Coding Standards
 
@@ -48,7 +53,7 @@ See the [Development Guide](https://seebom.cncf.io/docs/development/) for detail
 
 - All new features must have tests
 - Run `cd backend && go test ./... -count=1 -race` before submitting
-- See [Testing Guide](https://seebom.cncf.io/docs/development/testing/) for patterns and conventions
+- See [Testing Guide](https://docs.seebom.dev/docs/development/testing/) for patterns and conventions
 
 ## Pull Request Process
 
@@ -73,6 +78,21 @@ See the [Development Guide](https://seebom.cncf.io/docs/development/) for detail
 - **Never** commit secrets or API keys
 - **Never** add write APIs for license exceptions (frontend is public)
 - **Never** use a relational database for core SBOM data
+
+## AI-Assisted Contributions
+
+We welcome AI-assisted contributions (Copilot, ChatGPT, Claude, Cursor, etc.). Key rules:
+
+- **You sign, not the AI** — every commit needs your DCO sign-off (`git commit -s`)
+- **No `Co-authored-by: AI` trailers** — you are the sole author
+- **Follow [AGENTS.md](AGENTS.md)** — feed it to your AI tool for project context
+- **Review everything** — you're responsible for what you submit
+
+See the full [AI Usage Policy](https://docs.seebom.dev/docs/development/ai-policy/) for details.
+
+## Contributor Ladder
+
+We have a transparent contributor ladder: Community → Contributor → Reviewer → Maintainer. See the [Contributor Ladder](https://docs.seebom.dev/docs/development/contributor-ladder/) for promotion criteria and expectations at each level.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,18 @@
 <p align="center">
   <a href="https://github.com/seebom-labs/seebom/actions/workflows/ci.yml"><img src="https://github.com/seebom-labs/seebom/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/seebom-labs/seebom"><img src="https://api.scorecard.dev/projects/github.com/seebom-labs/seebom/badge" alt="OpenSSF Scorecard"></a>
-  <a href="https://www.bestpractices.dev/projects/TODO"><img src="https://www.bestpractices.dev/projects/TODO/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://www.bestpractices.dev/projects/12903"><img src="https://www.bestpractices.dev/projects/12903/badge" alt="OpenSSF Best Practices"></a>
 </p>
 
 Ingest 1000+ SPDX SBOMs, scan for vulnerabilities via OSV, enforce license compliance, and apply VEX statements — all visualized in a fast Angular dashboard backed by ClickHouse analytics.
+
+<p align="center">
+  <a href="https://docs.seebom.dev/docs/getting-started/">Getting Started</a> ·
+  <a href="https://docs.seebom.dev/docs/architecture/">Architecture</a> ·
+  <a href="https://docs.seebom.dev/docs/roadmap/">Roadmap</a> ·
+  <a href="https://docs.seebom.dev/docs/development/contributor-ladder/">Contributing</a> ·
+  <a href="https://docs.seebom.dev/docs/development/ai-policy/">AI Policy</a>
+</p>
 
 <p align="center">
   <img src="docs/static/images/dashboard-screenshot.png" alt="SeeBOM Dashboard" width="900">
@@ -329,7 +337,7 @@ sboms/*.spdx.json + *.openvex.json
              │
              ▼
 ┌─────────────────────────┐
-│   API Gateway           │  16 REST endpoints, stateless
+│   API Gateway           │  19 REST endpoints, stateless
 │   (Go binary)           │
 └────────────┬────────────┘
              │
@@ -358,7 +366,8 @@ The Parsing Worker processes each SBOM in a carefully ordered pipeline:
 See [docs/ARCHITECTURE_PLAN.md](docs/ARCHITECTURE_PLAN.md) for the full blueprint.  
 See [docs/DEPLOYMENT_GUIDE.md](docs/DEPLOYMENT_GUIDE.md) for Kubernetes deployment.  
 See [docs/RELEASE.md](docs/RELEASE.md) for building and publishing container images.  
-See [docs/TESTING.md](docs/TESTING.md) for writing and running tests.
+See [docs/TESTING.md](docs/TESTING.md) for writing and running tests.  
+See the [API Reference](https://docs.seebom.dev/docs/api-reference/) for complete endpoint documentation.
 
 ---
 
@@ -412,7 +421,8 @@ See [docs/TESTING.md](docs/TESTING.md) for writing and running tests.
 | GET | `/healthz` | Health check |
 | GET | `/api/v1/stats/dashboard` | Dashboard stats (VEX effective/suppressed counts) |
 | GET | `/api/v1/stats/dependencies?limit=N` | Top N dependencies across all projects |
-| GET | `/api/v1/sboms?page=&page_size=` | Paginated SBOM list |
+| GET | `/api/v1/stats/version-skew?page=&page_size=&search=` | Packages with inconsistent versions across projects |
+| GET | `/api/v1/sboms?page=&page_size=&search=` | Paginated SBOM list (searchable) |
 | GET | `/api/v1/sboms/{id}/detail` | SBOM detail with severity breakdown |
 | GET | `/api/v1/sboms/{id}/vulnerabilities` | Vulnerabilities for a specific SBOM |
 | GET | `/api/v1/sboms/{id}/licenses` | License breakdown for a specific SBOM |
@@ -425,6 +435,10 @@ See [docs/TESTING.md](docs/TESTING.md) for writing and running tests.
 | GET | `/api/v1/license-policy` | Active license classification policy (permissive/copyleft lists) |
 | GET | `/api/v1/vex/statements?page=&page_size=` | Paginated VEX statements |
 | GET | `/api/v1/packages/archived` | Packages using archived GitHub repos (no longer maintained) |
+| GET | `/api/v1/packages/search?q=&page=&page_size=` | Package name search across all SBOMs |
+| GET | `/api/v1/packages/detail?name=&page=&page_size=` | All projects using a specific package (paginated) |
+
+For complete API documentation with request/response examples, see the [API Reference](https://docs.seebom.dev/docs/api-reference/).
 
 ---
 
@@ -500,9 +514,21 @@ kubectl edit configmap seebom-license-policy -n seebom
 
 ---
 
+## Contributing
+
+We welcome contributions! See the [Contributing Guide](CONTRIBUTING.md) for how to get started.
+
+- 📖 [Full Documentation](https://docs.seebom.dev/)
+- 🗺️ [Roadmap](https://docs.seebom.dev/docs/roadmap/)
+- 🪜 [Contributor Ladder](https://docs.seebom.dev/docs/development/contributor-ladder/)
+- 🤖 [AI Usage Policy](https://docs.seebom.dev/docs/development/ai-policy/)
+- 🛡️ [Security Policy](SECURITY.md)
+
+---
+
 ## License
 
-[LICENSE](LICENSE)
+[Apache License 2.0](LICENSE)
 
 ## Badges
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,161 @@
+# SeeBOM Product Roadmap
+
+> Last updated: 2026-05-21
+> Project Board: https://github.com/orgs/seebom-labs/projects/1
+
+## Executive Summary
+
+SeeBOM is transitioning from a single-instance SBOM visualization tool into an **enterprise-grade, multi-cluster Software Supply Chain Security platform**. This roadmap outlines three phases spanning Q1-Q3 2026, progressing from foundational infrastructure (authentication, multi-cluster data model) through fleet-scale operations (push ingestion, namespace isolation) to advanced analytics (CRA compliance scoring, exploit prediction, dependency health).
+
+The sequencing is driven by dependency chains: multi-cluster support must land before fleet APIs, authentication must exist before write endpoints, and data enrichment (EPSS, Scorecard, Lottery Factor) builds on the mature query layer.
+
+---
+
+## Phase 1: Foundation & Security (Q1 2026 — Apr-Jun)
+
+**Theme:** Make SeeBOM deployable in production environments with real security requirements.
+
+| # | Issue | Rationale |
+|---|-------|-----------|
+| #131 | Cluster-aware data model | Foundational schema change — every multi-cluster feature depends on this. Non-destructive migration (ADD COLUMN DEFAULT). |
+| #134 | API Authentication (Service Token + API Key) | Zero dependencies, highest organizational demand. Cannot expose API externally or accept uploads without auth. OIDC explicitly out of scope — handled by upstream proxy/gateway. |
+| #137 | Enhanced health checks (/readyz, /livez) | Quick win. Production K8s deployments need proper probes before trusting traffic routing. |
+| #136 | Enhanced CORS configuration | Required by upload endpoint and external dashboard embedding. Small change, large enablement. |
+| #139 | Headless mode (API-only) | Helm-only change. Enables pure API consumers and reduces resource footprint for headless deployments. |
+| #8 | Project List View | Existing priority:high. Groups SBOMs by project — foundational UX improvement. |
+| #144 | SBOM Download | Small scope, high value. Users expect to download original SBOM JSON from the platform that aggregates them. Requires new API endpoint + UI button. |
+| #59 | Expose API externally (Ingress) | Helm template + docs. Pairs with auth (#134) for secure external access. |
+| #55 | CycloneDX Support | Already in progress (PR #110). Doubles the addressable market (Trivy, Grype users). |
+| ~~#37~~ | ~~Version Skew Detection~~ | ✅ **Done** (PRs #103, #126, merged 2026-05-04). |
+
+**Exit criteria:** SeeBOM can be deployed with authentication, multi-cluster tagging, and proper K8s health probes. CycloneDX SBOMs parse correctly.
+
+---
+
+## Phase 2: Multi-Cluster & Push Model (Q2 2026 — Jul-Sep)
+
+**Theme:** Enable fleet-scale operations — multiple clusters, push ingestion, namespace isolation, and audit exports.
+
+| # | Issue | Rationale |
+|---|-------|-----------|
+| #132 | Cluster listing endpoint | First consumer-visible multi-cluster feature. Enables cluster picker in frontend. |
+| #133 | Cluster-detail endpoints | Per-cluster deep-links. Cleaner than query params for frontend routing. |
+| #135 | SBOM Upload (Push Model) | Critical for CI/CD integration. Depends on auth (#134) and cluster model (#131). |
+| #138 | Namespace filtering | Sub-cluster granularity. Enterprise teams operate in namespaces, not just clusters. |
+| #140 | Workload vulnerability summary | The key cross-reference: image → posture. Powers compliance dashboards. |
+| #62 | Exportable Auditor Reports (PDF/CSV) | CRA compliance requires offline documentation. Auditors don't use UIs. |
+| #60 | Local OSV Mirror | Eliminates external dependency on osv.dev. Faster scans, offline capability, no rate limits. |
+| #57 | Per-project license policies | Enterprise reality: different products have different license constraints. |
+| #143 | In-toto Witness Integration | Supply chain attestation verification for ingested SBOMs. Provenance display, signature verification. Prerequisite for CRA compliance scoring (#141). |
+| #58 | Aggregated SBOM View | UX fix: group 50 versions of containerd into one expandable row. |
+
+**Exit criteria:** SeeBOM manages multiple clusters with namespace isolation, accepts SBOM pushes from CI/CD, generates PDF compliance reports, attestation verification, and doesn't depend on external OSV availability.
+
+### 🎯 v1.0.0 Milestone (Target: October 2026)
+
+After Phase 2 completes, SeeBOM reaches **v1.0.0** — the first stable release:
+
+- API contract frozen (no breaking changes without major version bump)
+- ClickHouse schema stable (no ORDER BY changes)
+- Helm chart values stable
+- Support policy (current − 2) takes effect
+- Versioned documentation enabled (#145)
+
+**v1.0 Criteria:**
+- [x] ~~Version Skew Detection~~ (#37)
+- [ ] API Authentication (#134)
+- [ ] Cluster-aware schema (#131)
+- [ ] All cluster/namespace endpoints finalized (#132, #133, #138)
+- [ ] Upload endpoint stable (#135)
+- [ ] CycloneDX parsing (#55)
+- [ ] Health probes (#137)
+- [ ] Versioned docs (#145)
+
+---
+
+## Phase 3: Analytics & Compliance (Q3 2026 — Oct-Dec)
+
+**Theme:** Advanced analytics, regulatory compliance scoring, and supply chain intelligence.
+
+| # | Issue | Rationale |
+|---|-------|-----------|
+| #141 | CRA Compliance Dashboard | EU Cyber Resilience Act goes live 2027. Organizations need readiness scoring NOW. |
+| #38 | SBOM Diff (tree divergence) | "What changed between v1.7.1 and v1.7.2?" — critical for change review. |
+| #56 | Dependency Tree View | Hierarchical visualization. Current flat list doesn't show transitive chains. |
+| #63 | Blast Radius Search (delta) | Extends v0.4.0 Package Search with version constraints, vuln context, direct/transitive classification. |
+| #64 | EPSS Scores | Exploit probability > CVSS severity for prioritization. Free daily bulk data from FIRST.org. |
+| #61 | OpenSSF Scorecard Integration | Upstream project health scoring. "Is this dependency well-maintained?" |
+| #82 | Lottery Factor | Single-maintainer risk detection. Supply chain resilience metric. |
+| #7 | CVE Fix Time (MTTR) | Mean-time-to-remediate is a key security KPI for audits (SOC2, ISO 27001). |
+
+**Exit criteria:** SeeBOM provides CRA readiness scoring, exploit-probability-based prioritization, dependency health metrics, and SBOM diff capabilities.
+
+---
+
+## Dependency Graph
+
+```
+#131 (Cluster Model) ─────┬── #132 (Cluster Listing)
+                          ├── #133 (Cluster Detail)
+                          ├── #138 (Namespace Filtering) ── #140 (Workload Summary) ── #141 (CRA Dashboard)
+                          └── #135 (Upload)
+                                    ↑
+#134 (Auth) ──────────────────────────┘
+#136 (CORS) ──────────────────────────┘
+
+#143 (Witness) ── standalone (feeds into #141 CRA Dashboard)
+#55 (CycloneDX) ── standalone
+#144 (SBOM Download) ── standalone
+#137 (Health Checks) ── standalone
+#139 (Headless Mode) ── standalone
+#60 (OSV Mirror) ── standalone
+#64 (EPSS) ── standalone (extends cve-refresher)
+#82 (Lottery Factor) ── extends internal/github
+#61 (Scorecard) ── extends internal/github
+```
+
+---
+
+## Prioritization Rationale
+
+### Why multi-cluster before analytics?
+
+Organizations evaluating SeeBOM for production ask: "Can it handle our 5 clusters?" before they ask "Does it have EPSS scores?" The cluster model is table-stakes for enterprise adoption.
+
+### Why auth before upload?
+
+A write endpoint without authentication is a security incident waiting to happen. Auth is the gate that unlocks all write operations safely. SeeBOM uses a lightweight service-token mode (shared secret with upstream proxy) rather than full OIDC — user authentication is the proxy's responsibility, not SeeBOM's.
+
+### Why CRA compliance in Q3?
+
+The EU Cyber Resilience Act enforcement begins 2027. Organizations need 6-12 months of tooling maturity before audits. Landing CRA scoring by end of 2026 gives early adopters a full year of runway.
+
+### Why EPSS/Scorecard/Lottery Factor together?
+
+These are all "data enrichment" features that follow the same pattern: fetch external data → store in ClickHouse → expose via API → display in frontend. Implementing them as a batch maximizes code reuse and architectural consistency.
+
+---
+
+## Success Metrics
+
+| Phase | Metric | Target |
+|-------|--------|--------|
+| Phase 1 | API can be deployed with auth in production | Service token + API key modes working, health probes passing |
+| Phase 2 | CI/CD pipeline pushes SBOM to SeeBOM | Upload endpoint processes 100 SBOMs/hour |
+| Phase 3 | CRA readiness score > 80% for managed clusters | All 5 CRA conditions evaluable |
+
+---
+
+## Non-Goals (Explicitly Out of Scope)
+
+- **Custom Kubernetes Operator**: We use standard Helm + ClickHouse Operator. No custom CRDs.
+- **Write APIs for license exceptions**: Frontend is public. Policy changes require config file updates.
+- **Multi-repo split**: Monorepo architecture is a hard constraint for AI-assisted development.
+- **Real-time streaming**: Batch ingestion (CronJob + queue) is sufficient for SBOM use cases.
+- **RBAC/multi-tenancy**: Auth is binary (authenticated or not). Fine-grained RBAC is a future consideration beyond this roadmap.
+- **Full OIDC in SeeBOM**: User-facing authentication is the upstream proxy/gateway's responsibility. SeeBOM only validates service tokens from trusted proxies.
+
+
+
+
+

--- a/docs/content/docs/api-reference/_index.md
+++ b/docs/content/docs/api-reference/_index.md
@@ -1,0 +1,721 @@
+---
+title: "API Reference"
+linkTitle: "API Reference"
+type: docs
+weight: 3
+description: >
+  Complete REST API reference for the SeeBOM API Gateway. Essential for headless deployments, CI/CD integrations, and custom tooling.
+---
+
+{{% alert title="Read-Only API" color="info" %}}
+The SeeBOM API is currently **read-only** (GET endpoints only). Write endpoints (SBOM upload) are planned for Phase 2 — see [Roadmap](/docs/roadmap/).
+{{% /alert %}}
+
+## Base URL
+
+```
+http://<api-gateway-host>:8080/api/v1
+```
+
+In headless mode (Helm: `ui.enabled: false`), only the API Gateway is deployed. All endpoints remain the same.
+
+## Authentication
+
+{{% alert title="Coming in v1.0" color="warning" %}}
+Authentication (service token + API key) is planned for Phase 1. Currently all endpoints are unauthenticated. Restrict access via network policy or ingress rules until then.
+{{% /alert %}}
+
+## Common Patterns
+
+### Pagination
+
+Paginated endpoints accept:
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `page` | uint64 | 1 | — | Page number (1-based) |
+| `page_size` | uint64 | 50 | 500 | Items per page |
+
+Paginated responses return:
+
+```json
+{
+  "data": [...],
+  "total": 1234,
+  "page": 1,
+  "page_size": 50
+}
+```
+
+### Error Responses
+
+All errors return:
+
+```json
+{
+  "error": "Human-readable error message"
+}
+```
+
+| HTTP Status | Meaning |
+|-------------|---------|
+| 400 | Bad Request — invalid parameters (malformed UUID, missing required query param) |
+| 429 | Too Many Requests — rate limit exceeded (100 req/10s per IP) |
+| 500 | Internal Server Error — database or processing failure |
+
+### Rate Limiting
+
+- **100 requests per 10 seconds** per source IP
+- Returns `429 Too Many Requests` when exceeded
+- No `Retry-After` header (client should implement exponential backoff)
+
+---
+
+## Health
+
+### `GET /healthz`
+
+Health check endpoint for Kubernetes probes.
+
+**Response:** `200 OK`
+```json
+{"status": "ok"}
+```
+
+---
+
+## Dashboard & Statistics
+
+### `GET /api/v1/stats/dashboard`
+
+Aggregated platform statistics for the dashboard view.
+
+**Response:** `200 OK`
+```json
+{
+  "total_sboms": 142,
+  "total_packages": 18743,
+  "total_vulnerabilities": 892,
+  "effective_vulnerabilities": 756,
+  "suppressed_by_vex": 136,
+  "critical_vulns": 23,
+  "high_vulns": 187,
+  "medium_vulns": 412,
+  "low_vulns": 270,
+  "license_breakdown": {
+    "Apache-2.0": 8421,
+    "MIT": 6234,
+    "BSD-3-Clause": 2100
+  },
+  "exempted_packages": 14,
+  "total_vex_statements": 42,
+  "last_cve_refresh": "2026-05-20T03:00:00Z",
+  "new_vulns_since_refresh": 3,
+  "archived_repos_count": 7
+}
+```
+
+### `GET /api/v1/stats/dependencies`
+
+Top-N most used dependencies across all projects.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | uint64 | 50 | Number of top dependencies to return (max 500) |
+
+**Response:** `200 OK`
+```json
+{
+  "total_unique_deps": 4521,
+  "top_dependencies": [
+    {
+      "package_name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net",
+      "project_count": 87,
+      "versions": ["v0.23.0", "v0.24.0", "v0.25.0"],
+      "vuln_count": 2
+    }
+  ]
+}
+```
+
+### `GET /api/v1/stats/version-skew`
+
+Packages with inconsistent versions across different projects (version skew detection).
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | uint64 | 1 | Page number |
+| `page_size` | uint64 | 50 | Items per page (max 500) |
+| `search` | string | — | Filter by package name (case-insensitive substring match) |
+
+**Response:** `200 OK`
+```json
+{
+  "total_skewed_packages": 234,
+  "items": [
+    {
+      "package_name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto",
+      "version_count": 4,
+      "project_count": 12,
+      "is_direct_in_count": 8,
+      "versions": [
+        {
+          "version": "v0.23.0",
+          "project_count": 5,
+          "projects": ["prometheus", "grafana", "etcd"]
+        },
+        {
+          "version": "v0.21.0",
+          "project_count": 3,
+          "projects": ["containerd", "runc"]
+        }
+      ]
+    }
+  ],
+  "page": 1,
+  "page_size": 50
+}
+```
+
+---
+
+## SBOMs
+
+### `GET /api/v1/sboms`
+
+Paginated list of all ingested SBOMs.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | uint64 | 1 | Page number |
+| `page_size` | uint64 | 50 | Items per page (max 500) |
+| `search` | string | — | Filter by document name or source file (case-insensitive) |
+
+**Response:** `200 OK`
+```json
+{
+  "data": [
+    {
+      "sbom_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "source_file": "containerd-v1.7.2.spdx.json",
+      "spdx_version": "SPDX-2.3",
+      "document_name": "containerd-v1.7.2",
+      "package_count": 245,
+      "vuln_count": 12,
+      "ingested_at": "2026-05-20T14:30:00Z"
+    }
+  ],
+  "total": 142,
+  "page": 1,
+  "page_size": 50
+}
+```
+
+### `GET /api/v1/sboms/{id}/detail`
+
+Detailed SBOM information including vulnerability severity breakdown.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | UUID | SBOM identifier |
+
+**Response:** `200 OK`
+```json
+{
+  "sbom_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "source_file": "containerd-v1.7.2.spdx.json",
+  "spdx_version": "SPDX-2.3",
+  "document_name": "containerd-v1.7.2",
+  "package_count": 245,
+  "vuln_count": 12,
+  "ingested_at": "2026-05-20T14:30:00Z",
+  "critical_vulns": 1,
+  "high_vulns": 3,
+  "medium_vulns": 6,
+  "low_vulns": 2
+}
+```
+
+**Errors:**
+- `400` — Invalid UUID format
+
+### `GET /api/v1/sboms/{id}/vulnerabilities`
+
+All vulnerabilities found in a specific SBOM, including VEX status.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | UUID | SBOM identifier |
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "vuln_id": "GHSA-xyz-abc-123",
+    "severity": "HIGH",
+    "purl": "pkg:golang/golang.org/x/net@v0.17.0",
+    "summary": "HTTP/2 rapid reset vulnerability",
+    "fixed_version": "v0.23.0",
+    "source_file": "containerd-v1.7.2.spdx.json",
+    "discovered_at": "2026-05-18T09:00:00Z",
+    "vex_status": "not_affected"
+  }
+]
+```
+
+### `GET /api/v1/sboms/{id}/licenses`
+
+License breakdown for a specific SBOM, grouped by license ID with package lists.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | UUID | SBOM identifier |
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "license_id": "Apache-2.0",
+    "category": "permissive",
+    "package_count": 120,
+    "packages": ["github.com/containerd/containerd", "..."],
+    "exempted_packages": [],
+    "exemption_reason": ""
+  },
+  {
+    "license_id": "GPL-2.0-only",
+    "category": "copyleft",
+    "package_count": 2,
+    "packages": ["github.com/some/gpl-lib"],
+    "exempted_packages": ["github.com/some/gpl-lib"],
+    "exemption_reason": "System library, not linked"
+  }
+]
+```
+
+### `GET /api/v1/sboms/{id}/dependencies`
+
+Dependency tree reconstructed as a flat array with parent→child index references.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | UUID | SBOM identifier |
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "index": 0,
+    "spdx_id": "SPDXRef-Package-containerd",
+    "name": "containerd",
+    "version": "1.7.2",
+    "purl": "pkg:golang/github.com/containerd/containerd@v1.7.2",
+    "license": "Apache-2.0",
+    "children": [1, 2, 3]
+  },
+  {
+    "index": 1,
+    "spdx_id": "SPDXRef-Package-runc",
+    "name": "runc",
+    "version": "1.1.12",
+    "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.12",
+    "license": "Apache-2.0",
+    "children": [4, 5]
+  }
+]
+```
+
+The UI reconstructs the tree by following `children` indices. Root nodes are those not referenced as children by any other node.
+
+---
+
+## Vulnerabilities
+
+### `GET /api/v1/vulnerabilities`
+
+Paginated list of all discovered vulnerabilities across all SBOMs.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | uint64 | 1 | Page number |
+| `page_size` | uint64 | 50 | Items per page (max 500) |
+| `vex_filter` | string | — | Filter mode: `effective` = exclude VEX-suppressed vulns |
+
+**Response:** `200 OK` — `PaginatedResponse<VulnerabilityListItem>`
+
+```json
+{
+  "data": [
+    {
+      "vuln_id": "CVE-2024-45338",
+      "severity": "CRITICAL",
+      "purl": "pkg:golang/golang.org/x/net@v0.21.0",
+      "summary": "Denial of service in net/http",
+      "fixed_version": "v0.23.0",
+      "source_file": "etcd-v3.5.12.spdx.json",
+      "discovered_at": "2026-05-15T00:00:00Z",
+      "vex_status": ""
+    }
+  ],
+  "total": 892,
+  "page": 1,
+  "page_size": 50
+}
+```
+
+### `GET /api/v1/vulnerabilities/{id}/affected-projects`
+
+All projects affected by a specific CVE, including transitive dependency information.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Vulnerability ID (CVE, GHSA, GO-*, PYSEC-*, etc.) |
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "sbom_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "source_file": "etcd-v3.5.12.spdx.json",
+    "document_name": "etcd-v3.5.12",
+    "purl": "pkg:golang/golang.org/x/net@v0.21.0",
+    "package_name": "golang.org/x/net",
+    "version": "v0.21.0",
+    "severity": "CRITICAL",
+    "vex_status": "",
+    "is_direct": false
+  }
+]
+```
+
+**Errors:**
+- `400` — Invalid vulnerability ID format
+
+---
+
+## Licenses
+
+### `GET /api/v1/licenses/compliance`
+
+Aggregated license compliance overview across all projects, with exemption details.
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "license_id": "GPL-3.0-only",
+    "category": "copyleft",
+    "package_count": 5,
+    "sbom_count": 3,
+    "non_compliant_packages": ["github.com/some/gpl3-lib"],
+    "exempted_packages": ["github.com/some/gpl3-lib"],
+    "exemption_reason": "Build tool only, not distributed",
+    "affected_sboms": [
+      {
+        "sbom_id": "a1b2c3d4-...",
+        "document_name": "my-project-v1.0"
+      }
+    ]
+  }
+]
+```
+
+### `GET /api/v1/projects/license-compliance`
+
+Projects with copyleft or unknown license packages (filtered by active exceptions).
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "sbom_id": "a1b2c3d4-...",
+    "source_file": "my-project.spdx.json",
+    "document_name": "my-project-v2.1",
+    "copyleft_count": 3,
+    "unknown_count": 1,
+    "violating_licenses": ["LGPL-2.1-only", "UNKNOWN"],
+    "non_compliant_packages": ["github.com/some/lgpl-lib", "github.com/unknown/pkg"]
+  }
+]
+```
+
+### `GET /api/v1/license-exceptions`
+
+Active license exceptions (read-only, loaded from config file).
+
+**Response:** `200 OK`
+```json
+{
+  "version": "1.0.0",
+  "blanket_exceptions": [
+    {
+      "license": "ISC",
+      "reason": "ISC is functionally equivalent to MIT"
+    }
+  ],
+  "exceptions": [
+    {
+      "purl_prefix": "pkg:golang/github.com/some/gpl-lib",
+      "license": "GPL-2.0-only",
+      "reason": "Build tool only, not distributed with binary"
+    }
+  ]
+}
+```
+
+### `GET /api/v1/license-policy`
+
+Active license classification policy (permissive vs. copyleft lists).
+
+**Response:** `200 OK`
+```json
+{
+  "permissive": [
+    "MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unlicense", "0BSD"
+  ],
+  "copyleft": [
+    "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "AGPL-3.0-only", "MPL-2.0"
+  ]
+}
+```
+
+---
+
+## VEX (Vulnerability Exploitability eXchange)
+
+### `GET /api/v1/vex/statements`
+
+Paginated list of all ingested VEX statements with affected SBOM cross-references.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | uint64 | 1 | Page number |
+| `page_size` | uint64 | 50 | Items per page (max 500) |
+
+**Response:** `200 OK` — `PaginatedResponse<VEXStatementItem>`
+
+```json
+{
+  "data": [
+    {
+      "vex_id": "https://example.com/vex/2024-001",
+      "document_id": "https://openvex.dev/docs/example/v1",
+      "source_file": "golang-common.openvex.json",
+      "product_purl": "pkg:golang/golang.org/x/net",
+      "vuln_id": "CVE-2024-45338",
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The vulnerable HTTP/2 code path is not used",
+      "action_statement": "",
+      "vex_timestamp": "2024-12-01T00:00:00Z",
+      "ingested_at": "2026-05-20T14:30:00Z",
+      "affected_sboms": [
+        {
+          "sbom_id": "a1b2c3d4-...",
+          "document_name": "etcd-v3.5.12"
+        }
+      ]
+    }
+  ],
+  "total": 42,
+  "page": 1,
+  "page_size": 50
+}
+```
+
+---
+
+## Packages
+
+### `GET /api/v1/packages/search`
+
+Search packages by name across all ingested SBOMs.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `q` | string | ✅ | Search query (case-insensitive substring match) |
+| `page` | uint64 | — | Page number (default 1) |
+| `page_size` | uint64 | — | Items per page (default 50, max 500) |
+
+**Response:** `200 OK`
+```json
+{
+  "total_results": 15,
+  "items": [
+    {
+      "package_name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto",
+      "project_count": 87,
+      "versions": ["v0.21.0", "v0.22.0", "v0.23.0"],
+      "projects": [
+        {
+          "project_name": "etcd-v3.5.12",
+          "version": "v0.21.0",
+          "sbom_id": "a1b2c3d4-..."
+        }
+      ]
+    }
+  ],
+  "page": 1,
+  "page_size": 50,
+  "query": "crypto"
+}
+```
+
+**Errors:**
+- `400` — Missing required query parameter `q`
+
+### `GET /api/v1/packages/detail`
+
+Detailed information about a specific package, listing all projects that use it.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | ✅ | Exact package name |
+| `page` | uint64 | — | Page number (default 1) |
+| `page_size` | uint64 | — | Items per page (default 50, max 500) |
+
+**Response:** `200 OK`
+```json
+{
+  "package_name": "golang.org/x/crypto",
+  "total_projects": 87,
+  "projects": [
+    {
+      "project_name": "etcd-v3.5.12",
+      "version": "v0.21.0",
+      "sbom_id": "a1b2c3d4-..."
+    }
+  ],
+  "page": 1,
+  "page_size": 50
+}
+```
+
+**Errors:**
+- `400` — Missing required query parameter `name`
+
+### `GET /api/v1/packages/archived`
+
+Packages from archived/unmaintained GitHub repositories (supply chain risk indicator).
+
+**Response:** `200 OK`
+```json
+[
+  {
+    "package_name": "github.com/abandoned/lib",
+    "purl": "pkg:golang/github.com/abandoned/lib",
+    "archived_since": "2023-06-15",
+    "project_count": 4,
+    "projects": ["etcd-v3.5.12", "containerd-v1.7.2"]
+  }
+]
+```
+
+---
+
+## Security Headers
+
+All responses include:
+
+| Header | Value |
+|--------|-------|
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Content-Security-Policy` | `default-src 'none'; frame-ancestors 'none'` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
+
+## CORS
+
+Configured via `CORS_ALLOWED_ORIGINS` environment variable.
+
+- Default: `*` (development)
+- Production: Set to your frontend domain(s)
+- Allowed methods: `GET`, `OPTIONS`
+- Allowed headers: `Content-Type`, `Authorization`
+
+---
+
+## Headless Mode
+
+When deployed with `ui.enabled: false` in Helm values, SeeBOM runs as a pure API service:
+
+- All endpoints above remain available
+- No UI container is deployed
+- No Nginx, no static file serving
+- Ideal for CI/CD integrations, custom dashboards, or aggregation by external tools
+
+```yaml
+# values-headless.yaml
+ui:
+  enabled: false
+
+apiGateway:
+  ingress:
+    enabled: true
+    hosts:
+      - sbom-api.internal.example.com
+```
+
+---
+
+## Usage Examples
+
+### curl
+
+```bash
+# Get dashboard overview
+curl -s http://localhost:8080/api/v1/stats/dashboard | jq .
+
+# Search SBOMs
+curl -s "http://localhost:8080/api/v1/sboms?search=containerd&page_size=10" | jq .
+
+# Get vulnerabilities (effective only, VEX-filtered)
+curl -s "http://localhost:8080/api/v1/vulnerabilities?vex_filter=effective&page_size=100" | jq .
+
+# Check which projects are affected by a CVE
+curl -s http://localhost:8080/api/v1/vulnerabilities/CVE-2024-45338/affected-projects | jq .
+
+# Search packages
+curl -s "http://localhost:8080/api/v1/packages/search?q=crypto" | jq .
+```
+
+### CI/CD Integration (GitHub Actions)
+
+```yaml
+- name: Check for critical vulnerabilities
+  run: |
+    CRITICAL=$(curl -sf "$SEEBOM_URL/api/v1/stats/dashboard" | jq '.critical_vulns')
+    if [ "$CRITICAL" -gt 0 ]; then
+      echo "::error::$CRITICAL critical vulnerabilities detected"
+      exit 1
+    fi
+```
+

--- a/docs/content/docs/development/ai-policy.md
+++ b/docs/content/docs/development/ai-policy.md
@@ -1,0 +1,139 @@
+---
+title: "AI Usage Policy"
+linkTitle: "AI Policy"
+type: docs
+weight: 4
+description: >
+  Guidelines for using AI tools (Copilot, ChatGPT, Claude, Cursor, etc.) when contributing to SeeBOM.
+---
+
+## Policy
+
+SeeBOM **welcomes AI-assisted contributions**. We use AI tools extensively in our own development workflow (see [AGENTS.md](https://github.com/seebom-labs/seebom/blob/main/AGENTS.md)). However, we have clear rules to ensure accountability and code quality.
+
+---
+
+## Rules
+
+### 1. You own it
+
+If you use AI to generate code, **you are responsible** for that code. Review it, test it, and understand it before submitting. "The AI wrote it" is not an excuse for bugs, security issues, or convention violations.
+
+### 2. Sign your commits
+
+Every commit must carry your DCO sign-off (`Signed-off-by: Your Name <your@email.com>`). This is **non-negotiable** — it certifies that *you* are the author and take responsibility, regardless of whether AI assisted you.
+
+```bash
+git commit -s -m "feat: add attestation verification"
+```
+
+### 3. No `Co-authored-by: AI` trailers
+
+AI is a tool, not a co-author. We do **not** accept commits with `Co-authored-by` trailers attributing AI tools (e.g., `Co-authored-by: github-copilot[bot]`). The human who submits the PR is the sole author and takes full responsibility.
+
+### 4. Follow AGENTS.md
+
+If you use AI coding agents, they must follow our project conventions documented in [AGENTS.md](https://github.com/seebom-labs/seebom/blob/main/AGENTS.md). This includes:
+
+- Architectural directives (monorepo, no custom operator, no polyrepo)
+- Dependency restrictions (only 4 Go deps, no new ones without asking)
+- Security boundaries (parameterized queries, no `bypassSecurityTrustHtml`)
+- Code style (idiomatic Go, OnPush Angular, MergeTree ClickHouse)
+
+{{% alert title="Tip" color="success" %}}
+Feed `AGENTS.md` to your AI tool as context. It was written specifically for this purpose — it gives AI agents all the constraints they need to produce code that fits our project.
+{{% /alert %}}
+
+### 5. Don't submit blindly
+
+AI-generated code must pass the same bar as hand-written code:
+
+- All tests pass (`go test ./... -count=1 -race`, `npx ng test`)
+- No new lint/vet warnings (`go vet ./...`)
+- Security boundaries respected
+- Matches existing patterns and conventions
+- Documentation updated if user-facing behavior changes
+
+### 6. Disclose when asked
+
+Reviewers may ask if AI was used for a specific PR. Be honest. There is **no penalty** for using AI — but there *is* a penalty for submitting broken or unreviewed code.
+
+---
+
+## Why This Policy?
+
+| Principle | Reason |
+|-----------|--------|
+| **Accountability** | The DCO sign-off is a legal certification. A human must stand behind each contribution. |
+| **Quality** | AI tools produce plausible-looking code that may have subtle bugs, security issues, or architectural violations. Human review is mandatory. |
+| **Consistency** | AGENTS.md gives AI tools the context they need. Using it produces better code. |
+| **Simplicity** | One author per commit. No ambiguity about who to contact for questions or fixes. |
+
+---
+
+## TL;DR
+
+| ✅ Allowed | ❌ Not Allowed |
+|-----------|---------------|
+| Use AI to write code, tests, docs | Submit AI output without review |
+| Use AI to explore approaches | Add `Co-authored-by: <AI tool>` |
+| Use AI for refactoring | Let AI commit without your sign-off |
+| Reference AGENTS.md in AI prompts | Ignore project conventions because "the AI did it" |
+| Use any AI tool you prefer | Blame AI for bugs in your PR |
+| Generate issue descriptions with AI | Submit issues without verifying accuracy |
+
+---
+
+## Recommended Workflow
+
+Here's how we recommend using AI effectively with SeeBOM:
+
+```bash
+# 1. Give your AI tool the project context
+#    (paste AGENTS.md or use it as system prompt)
+
+# 2. Let AI generate code
+
+# 3. Review the output:
+#    - Does it follow our conventions?
+#    - Does it add unwanted dependencies?
+#    - Does it handle errors properly?
+#    - Are there security concerns?
+
+# 4. Run the checks yourself
+cd backend && go test ./... -count=1 -race
+cd backend && go vet ./...
+cd ui && npx ng test
+
+# 5. Commit with YOUR sign-off
+git add .
+git commit -s -m "feat(api): add attestation verification endpoint"
+
+# 6. Push and open a PR
+git push origin my-feature
+```
+
+---
+
+## FAQ
+
+### Can I use AI to write my entire PR?
+
+Yes — as long as you review every line, understand what it does, test it, and sign off on it. The bar is the same whether you typed it or an AI did.
+
+### Do I need to disclose AI usage in my PR description?
+
+Not required, but appreciated. If a reviewer asks, be honest.
+
+### What if the AI violates AGENTS.md conventions?
+
+Fix it before submitting. You're responsible for the final output, not the AI.
+
+### Can I use AI-generated commit messages?
+
+Yes, but make sure they follow [Conventional Commits](https://www.conventionalcommits.org/) format and accurately describe the change. Don't let AI hallucinate what it changed.
+
+### What about AI-generated issue descriptions?
+
+Welcome! But verify that the technical details are accurate against the actual codebase. AI can (and does) hallucinate file paths, function names, and architectural details.
+

--- a/docs/content/docs/development/contributor-ladder.md
+++ b/docs/content/docs/development/contributor-ladder.md
@@ -1,0 +1,206 @@
+---
+title: "Contributor Ladder"
+linkTitle: "Contributor Ladder"
+type: docs
+weight: 3
+description: >
+  How to grow from first-time contributor to maintainer — roles, expectations, and promotion criteria.
+---
+
+## Overview
+
+SeeBOM uses a transparent contributor ladder inspired by the [CNCF contributor ladder template](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md). Each rung provides clear expectations and privileges, so you always know what the next step looks like.
+
+```text
+┌─────────────────────────────────────────────┐
+│  Maintainer   — merge, release, direction   │
+├─────────────────────────────────────────────┤
+│  Reviewer     — approve PRs in their area   │
+├─────────────────────────────────────────────┤
+│  Contributor  — regular code/docs/tests     │
+├─────────────────────────────────────────────┤
+│  Community    — issues, discussions, usage   │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## 🌱 Community Member
+
+**Who:** Anyone who uses SeeBOM, files issues, or participates in discussions.
+
+**How to become one:** Just show up! No formal process.
+
+**Expectations:**
+- Follow the [Code of Conduct](https://github.com/seebom-labs/seebom/blob/main/CODE_OF_CONDUCT.md)
+- File bugs and feature requests using the issue templates
+- Help answer questions in discussions
+
+**Privileges:**
+- Open issues and participate in discussions
+- Submit pull requests
+
+---
+
+## 🔧 Contributor
+
+**Who:** Community members who have had at least one pull request merged.
+
+**How to become one:** Get a PR merged. That's it.
+
+**Expectations:**
+- Sign off commits (Developer Certificate of Origin: `git commit -s`)
+- Follow coding standards (see [Development Guide](/docs/development/))
+- Write tests for new features
+- Respond to review feedback in a timely manner
+
+**Privileges:**
+- Listed in release notes as a contributor
+- Can be assigned to issues
+- Eligible for `help wanted` and `good first issue` tasks
+
+### Good First Contributions
+
+| Area | Examples |
+|------|----------|
+| **Documentation** | Fix typos, improve examples, add FAQ entries |
+| **Tests** | Add unit tests for uncovered code paths |
+| **Bug fixes** | Issues labeled [`bug`](https://github.com/seebom-labs/seebom/labels/bug) |
+| **Frontend** | Small UI improvements, accessibility fixes |
+| **Backend** | Small query optimizations, error message improvements |
+
+### Coding Standards Quick Reference
+
+| Stack | Key Rules |
+|-------|-----------|
+| **Go** | Idiomatic, explicit error handling, `goccy/go-json`, parameterized queries, no new deps without asking |
+| **Angular** | Strict TypeScript, standalone components, OnPush, Vitest, never `bypassSecurityTrustHtml` |
+| **ClickHouse** | MergeTree family, batch inserts, low-cardinality ORDER BY prefix |
+| **Helm** | Standard templates, ClickHouse Operator for DB, no custom CRDs |
+
+---
+
+## 👀 Reviewer
+
+**Who:** Contributors who have demonstrated sustained, high-quality contributions in a specific area and are trusted to approve PRs.
+
+**How to become one:**
+1. Have **5+ merged PRs** in the area you want to review
+2. Demonstrate understanding of the codebase architecture and conventions
+3. Nominated by a maintainer, confirmed via lazy consensus (no objection in 7 days)
+
+**Expectations:**
+- Provide timely, constructive reviews (target: 48h for first response)
+- Ensure code quality, test coverage, and documentation
+- Help mentor new contributors
+- Prioritize unblocking others over your own PRs
+
+**Privileges:**
+- Can approve PRs in their area (final merge still requires maintainer)
+- Listed in [OWNERS](https://github.com/seebom-labs/seebom/blob/main/OWNERS) file
+- Invited to architecture discussions
+
+### Review Areas
+
+| Area | Scope |
+|------|-------|
+| **Backend / Core** | `cmd/`, `internal/`, `pkg/` — Go binaries and shared packages |
+| **Frontend** | `ui/` — Angular components, services, routing |
+| **Infrastructure** | `deploy/`, `Makefile`, `docker-compose.yml`, `.github/` |
+| **Database** | `db/migrations/`, ClickHouse schema changes |
+| **Documentation** | `docs/`, `README.md`, `ARCHITECTURE_PLAN.md` |
+
+---
+
+## 🛡️ Maintainer
+
+**Who:** The project's technical leadership with full write access and release authority.
+
+**How to become one:**
+1. Be an active Reviewer for **3+ months**
+2. Demonstrate deep understanding of the full architecture (not just one area)
+3. Show good judgment on API design, security, and backward compatibility
+4. Nominated by an existing maintainer, approved by **supermajority (⅔)** of current maintainers
+
+**Expectations:**
+- Set technical direction and own the [Roadmap](/docs/roadmap/)
+- Review and merge pull requests across all areas
+- Cut releases (tag → CI → publish)
+- Manage CI/CD pipeline and infrastructure
+- Enforce Code of Conduct and resolve disputes
+- Mentor reviewers and contributors
+- Be responsive: triage new issues within 7 days
+
+**Privileges:**
+- Write access to the repository
+- Merge pull requests
+- Cut releases
+- Manage GitHub project board and labels
+- Represent the project externally
+
+### Current Maintainers
+
+| Name | GitHub | Area | Affiliation |
+|------|--------|------|-------------|
+| Mario Fahlandt | [@mfahlandt](https://github.com/mfahlandt) | Project Lead / Core | Kubermatic |
+| Koray Oksay | [@koksay](https://github.com/koksay) | K8s Implementation | Kubermatic |
+
+---
+
+## 🏛️ Emeritus
+
+Maintainers or reviewers who are no longer active may be moved to **emeritus** status. This is a recognition of past contributions, not a demotion. Emeritus members:
+
+- Are listed in project history with gratitude
+- No longer have active review or merge permissions
+- Can return to active status by request + re-confirmation from current maintainers
+
+---
+
+## Promotion Process
+
+```text
+Community → Contributor:     First merged PR (automatic)
+Contributor → Reviewer:      Nominated by maintainer, 7-day lazy consensus
+Reviewer → Maintainer:       Nominated by maintainer, ⅔ supermajority vote
+Active → Emeritus:           Self-request or 6 months of inactivity + maintainer consensus
+```
+
+### What We Look For
+
+Beyond code quantity, promotion decisions consider:
+
+- **Quality** — Are PRs well-tested, documented, and maintainable?
+- **Consistency** — Are contributions sustained over time (not just a burst)?
+- **Collaboration** — Do you help others, respond to reviews, and communicate well?
+- **Judgment** — Do you make good trade-offs? Do you know when to ask vs. decide?
+- **Alignment** — Do your contributions advance the project's mission and roadmap?
+
+---
+
+## 🤖 AI Usage Policy
+
+We welcome AI-assisted contributions. See the dedicated [AI Usage Policy](/docs/development/ai-policy/) for full guidelines.
+
+**Key points:**
+- AI usage is welcome — you are responsible for the output
+- DCO sign-off (`git commit -s`) is mandatory — you sign, not the AI
+- No `Co-authored-by: AI` trailers — AI is a tool, not a co-author
+- Follow [AGENTS.md](https://github.com/seebom-labs/seebom/blob/main/AGENTS.md) conventions
+
+---
+
+## Getting Started
+
+Ready to climb the ladder? Here's how:
+
+1. **Browse issues** labeled [`good first issue`](https://github.com/seebom-labs/seebom/labels/good%20first%20issue) or [`help wanted`](https://github.com/seebom-labs/seebom/labels/help%20wanted)
+2. **Set up your dev environment** — see [Development Guide](/docs/development/)
+3. **Read the architecture** — see [Architecture](/docs/architecture/)
+4. **Submit a PR** — follow the [Contributing Guide](https://github.com/seebom-labs/seebom/blob/main/CONTRIBUTING.md)
+5. **Check the Roadmap** — see [Roadmap](/docs/roadmap/) for what's planned next
+
+{{% alert title="Questions?" color="info" %}}
+Don't hesitate to open a [Discussion](https://github.com/seebom-labs/seebom/discussions) if you're unsure where to start or how to contribute. We're happy to help!
+{{% /alert %}}
+

--- a/docs/content/docs/faq/_index.md
+++ b/docs/content/docs/faq/_index.md
@@ -2,7 +2,7 @@
 title: "FAQ"
 linkTitle: "FAQ"
 type: docs
-weight: 6
+weight: 8
 description: >
   Frequently asked questions about operating and troubleshooting SeeBOM.
 ---

--- a/docs/content/docs/release/_index.md
+++ b/docs/content/docs/release/_index.md
@@ -4,36 +4,229 @@ linkTitle: "Release"
 type: docs
 weight: 5
 description: >
-  Release process, CI workflows, container images, and Helm chart publishing.
+  Release process, support policy, versioning, CI workflows, and container images.
 ---
-## Container Images
-All images are published to **GitHub Container Registry (ghcr.io)**.
-Images are built for **linux/amd64** and **linux/arm64**.
+
+## Support Policy
+
+{{% alert title="Effective from v1.0" color="info" %}}
+This support policy applies starting with the first stable release (v1.0.0). All pre-1.0 releases are development milestones without backward-compatibility guarantees.
+{{% /alert %}}
+
+SeeBOM supports the **current stable release plus the two previous minor versions** (current − 2).
+
+### Support Matrix (example)
+
+| Version | Status | Security Fixes | Bug Fixes | Docs |
+|---------|--------|:--------------:|:---------:|:----:|
+| v1.3.x (main) | Development | ✅ | ✅ | `latest` |
+| **v1.2.x** | **Current Stable** | ✅ | ✅ | `/v1.2/` |
+| v1.1.x | Supported | ✅ | Critical only | `/v1.1/` |
+| v1.0.x | Supported (last) | ✅ | Critical only | `/v1.0/` |
+| v0.x | **End of Life** | ❌ | ❌ | `/v0.x/` (archived) |
+
+When a new minor version is released (e.g., v1.3.0):
+- The oldest supported version (v1.0.x) moves to **End of Life**
+- Its docs remain accessible but display an "unsupported version" banner
+- No further patches are backported
+
+### What "supported" means
+
+- **Security fixes**: CVEs in SeeBOM's own code or critical dependency updates are backported
+- **Bug fixes (current stable)**: All confirmed bugs are fixed
+- **Bug fixes (older supported)**: Only critical/data-loss bugs are backported
+- **Features**: Only land in `main` (next release), never backported
+
+---
+
+## Versioning
+
+SeeBOM follows [Semantic Versioning](https://semver.org/):
+
+| Component | Format | Example |
+|-----------|--------|---------|
+| Git tag | `vMAJOR.MINOR.PATCH` | `v1.2.3` |
+| Container image tag | `MAJOR.MINOR.PATCH` (no `v`) + `latest` | `1.2.3` |
+| Helm chart version | Matches Git tag | `1.2.3` |
+
+### Version types
+
+- **Major** (v2.0.0) — Breaking changes to API, schema, or configuration
+- **Minor** (v1.3.0) — New features, backward-compatible
+- **Patch** (v1.2.1) — Bug fixes, security patches, no new features
+
+### Major Version Philosophy
+
+SeeBOM plans for **one major version bump every 2–3 years**, driven by accumulated breaking changes — not by calendar. We do not stay on 1.x forever, but we also don't bump majors for marketing reasons.
+
+**Triggers for a major version:**
+- ClickHouse schema redesign (ORDER BY changes, table splits/merges)
+- API contract breaks (`/api/v2/` introduction)
+- Fundamental architecture shifts (e.g., multi-tenant RBAC, new ingestion protocol)
+- Helm values restructuring that breaks existing `values.yaml` files
+
+**What a major version provides:**
+- Clean slate for accumulated tech debt and design lessons
+- Clear migration window for enterprise adopters (migration guide required)
+- Marketing momentum for significant capability jumps
+
+**Constraints:**
+- The previous major version receives security patches for **12 months** after the new major GA
+- A **migration guide** with automated tooling (schema migration scripts, Helm values converter) is mandatory before tagging any major release
+- Major versions are announced **at least 3 months** in advance via the roadmap
+
+**Projected timeline:**
+- v1.0 — October 2026 (first stable)
+- v2.0 — Earliest Q1/Q2 2028 (after 12–18 months of production feedback on 1.x)
+
+---
+
 ## How to Release
+
+### Minor / Major Release
+
 ```bash
-git tag v0.1.2
-git push origin v0.1.2
+# 1. Ensure main is clean and CI passes
+git checkout main && git pull
+
+# 2. Tag the release
+git tag v1.3.0
+git push origin v1.3.0
+
+# 3. CI automatically:
+#    - Builds all 5 images (multi-arch: amd64 + arm64)
+#    - Signs images with cosign (keyless)
+#    - Attests provenance (SLSA)
+#    - Packages and pushes Helm chart
+#    - Creates GitHub Release with SBOM + changelog
+
+# 4. Create release branch for future patches
+git checkout -b release/v1.3
+git push origin release/v1.3
 ```
-The GitHub Actions workflow triggers on any `v*` tag and builds all 5 images (multi-arch), pushes the Helm chart as an OCI artifact, and creates a GitHub Release.
+
+### Minor Release Checklist
+
+- [ ] All planned features for this milestone merged to `main`
+- [ ] CI passes on `main`
+- [ ] `govulncheck ./...` (backend), `npm audit` (ui + docs) clean
+- [ ] **`ROADMAP.md` updated**: move completed items to "Done", adjust phase timelines if needed
+- [ ] `docs/ARCHITECTURE_PLAN.md` reflects any new services or schema changes
+- [ ] Tag created (`vX.Y.0`) and pushed
+- [ ] Release branch created (`release/vX.Y`) and pushed
+- [ ] Release notes written (features, breaking changes, upgrade notes)
+- [ ] Helm chart version matches Git tag
+
+### Patch Release
+
+Patches are cherry-picked onto the release branch:
+
+```bash
+# 1. Fix the bug on main first (always)
+git checkout main
+# ... make fix, get PR merged ...
+
+# 2. Cherry-pick to release branch
+git checkout release/v1.2
+git cherry-pick <commit-sha>
+git push origin release/v1.2
+
+# 3. Tag the patch
+git tag v1.2.4
+git push origin v1.2.4
+
+# CI builds and publishes automatically
+```
+
+### Patch Release Checklist
+
+- [ ] Fix merged to `main` first (never patch-only)
+- [ ] Cherry-picked cleanly to `release/vX.Y` branch
+- [ ] No new features included (patches are bug/security fixes only)
+- [ ] CI passes on the release branch
+- [ ] Tag follows existing sequence (v1.2.3 → v1.2.4)
+- [ ] Release notes mention the fix and affected versions
+
+---
+
+## Documentation for Releases
+
+Docs are versioned at the **minor** level (not per patch):
+
+```
+docs.seebom.dev/           ← latest (main)
+docs.seebom.dev/v1.2/      ← v1.2.0, v1.2.1, v1.2.2, ... share these docs
+docs.seebom.dev/v1.1/      ← v1.1.x docs (frozen at last patch)
+docs.seebom.dev/v1.0/      ← v1.0.x docs (frozen)
+```
+
+### When releasing a new minor version:
+
+1. Create `release/vX.Y` branch (docs freeze point)
+2. Update `docs/hugo.toml` on the release branch: add versioned `baseURL`
+3. Add new version to `params.versions` on both `main` and release branch
+4. Mark the oldest supported version's docs with "unsupported" banner
+
+### Doc fixes for patches:
+
+- Fix docs on `main` first
+- Cherry-pick to the release branch if the fix is relevant for that version
+- Deploy triggers automatically on push to release branches
+
+See [#145](https://github.com/seebom-labs/seebom/issues/145) for the full versioned docs implementation plan.
+
+---
+
+## Container Images
+
+All images are published to **GitHub Container Registry (ghcr.io)**.
+
+Images are built for **linux/amd64** and **linux/arm64**.
+
+| Image | Purpose |
+|-------|---------|
+| `ghcr.io/seebom-labs/seebom/api-gateway` | REST API server |
+| `ghcr.io/seebom-labs/seebom/parsing-worker` | SBOM processing worker |
+| `ghcr.io/seebom-labs/seebom/ingestion-watcher` | File scanner / queue enqueuer |
+| `ghcr.io/seebom-labs/seebom/cve-refresher` | Daily CVE refresh |
+| `ghcr.io/seebom-labs/seebom/ui` | Angular frontend (Nginx) |
+
+All images are:
+- Signed with [cosign](https://github.com/sigstore/cosign) (keyless via Fulcio)
+- Attested with SLSA provenance (`actions/attest-build-provenance`)
+
+### Verifying signatures
+
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/seebom-labs/seebom" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/seebom-labs/seebom/api-gateway:1.2.3
+```
+
 ## Installing from a Release
+
 ```bash
 helm install seebom oci://ghcr.io/seebom-labs/seebom/charts/seebom \
-  --version 0.1.2 \
+  --version 1.2.3 \
   -f values-production.yaml
 ```
+
 ## CI Workflows
+
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
 | CI | Push/PR to main | Go build + test + vet, Angular build, Helm lint |
-| Release | Git tag v* | Build + push images, Helm chart, GitHub Release |
+| Release | Git tag `v*` | Build + push images, sign, attest, Helm chart, GitHub Release |
 | Pre-Release | Manual | Build from any branch, create pre-release |
+| Fuzz | Weekly + PRs touching `backend/` | SPDX and VEX parser fuzz tests |
+| CodeQL | Push/PR | SAST for Go and TypeScript |
+| Scorecard | Weekly | OpenSSF Scorecard analysis |
+
 ## Building Images Locally
+
 ```bash
 make images            # Build all 5 images with tag "dev"
 make images TAG=0.2.0  # Build with a specific tag
 make images-push       # Build and push to GHCR
 ```
-## Versioning
-- **Git tags**: v0.1.2 (SemVer)
-- **Image tags**: 0.1.3 (without v) + latest
-- **Helm chart version**: Matches the Git tag

--- a/docs/content/docs/roadmap/_index.md
+++ b/docs/content/docs/roadmap/_index.md
@@ -1,0 +1,192 @@
+---
+title: "Roadmap"
+linkTitle: "Roadmap"
+type: docs
+weight: 6
+description: >
+  Product roadmap for SeeBOM — phased delivery from foundation to enterprise-grade supply chain security.
+---
+
+{{% alert title="Last Updated" color="info" %}}
+2026-05-21 · [Project Board →](https://github.com/orgs/seebom-labs/projects/1)
+{{% /alert %}}
+
+## Vision
+
+SeeBOM is transitioning from a single-instance SBOM visualization tool into an **enterprise-grade, multi-cluster Software Supply Chain Security platform**. The roadmap spans three phases (Q1–Q3 2026), each building on the previous:
+
+1. **Foundation & Security** — authentication, multi-cluster model, production readiness
+2. **Multi-Cluster & Push Model** — fleet operations, CI/CD integration, attestation verification
+3. **Analytics & Compliance** — CRA scoring, exploit prediction, dependency health metrics
+
+---
+
+## Phase 1: Foundation & Security {#phase-1}
+
+**Q1 2026 (Apr–Jun) · Theme:** Make SeeBOM production-ready with real security requirements.
+
+| Status | Issue | Description |
+|:------:|-------|-------------|
+| 🔲 | [#131 — Cluster-aware data model](https://github.com/seebom-labs/seebom/issues/131) | Add `cluster_id` to all tables. Every multi-cluster feature depends on this. |
+| 🔲 | [#134 — API Authentication](https://github.com/seebom-labs/seebom/issues/134) | Service token + API key modes. Gate for all write operations. |
+| 🔲 | [#137 — Enhanced health checks](https://github.com/seebom-labs/seebom/issues/137) | `/readyz`, `/livez` with dependency verification for K8s probes. |
+| 🔲 | [#136 — Enhanced CORS](https://github.com/seebom-labs/seebom/issues/136) | Support POST + custom headers for upload and cross-origin access. |
+| 🔲 | [#139 — Headless mode](https://github.com/seebom-labs/seebom/issues/139) | API-only deployment without Angular UI (Helm toggle). |
+| 🔲 | [#8 — Project List View](https://github.com/seebom-labs/seebom/issues/8) | Group SBOMs by project — foundational UX improvement. |
+| 🔲 | [#144 — SBOM Download](https://github.com/seebom-labs/seebom/issues/144) | Download original SBOM JSON from the platform. |
+| 🔲 | [#59 — Expose API externally](https://github.com/seebom-labs/seebom/issues/59) | Helm Ingress template for secure external access. |
+| 🔲 | [#55 — CycloneDX Support](https://github.com/seebom-labs/seebom/issues/55) | Parse CycloneDX 1.4+ SBOMs (doubles addressable market). |
+| ✅ | [~~#37 — Version Skew Detection~~](https://github.com/seebom-labs/seebom/issues/37) | Cross-org dependency consistency. Merged 2026-05-04. |
+
+**Exit criteria:** SeeBOM deployable with authentication, multi-cluster tagging, proper K8s probes, and CycloneDX parsing.
+
+---
+
+## Phase 2: Multi-Cluster & Push Model {#phase-2}
+
+**Q2 2026 (Jul–Sep) · Theme:** Enable fleet-scale operations — multiple clusters, push ingestion, attestation verification.
+
+| Status | Issue | Description |
+|:------:|-------|-------------|
+| 🔲 | [#132 — Cluster listing endpoint](https://github.com/seebom-labs/seebom/issues/132) | First consumer-visible multi-cluster feature. |
+| 🔲 | [#133 — Cluster-detail endpoints](https://github.com/seebom-labs/seebom/issues/133) | Per-cluster deep-links for frontend routing. |
+| 🔲 | [#135 — SBOM Upload (Push Model)](https://github.com/seebom-labs/seebom/issues/135) | Accept SBOMs from CI/CD pipelines via POST API. |
+| 🔲 | [#138 — Namespace filtering](https://github.com/seebom-labs/seebom/issues/138) | Sub-cluster granularity for enterprise teams. |
+| 🔲 | [#140 — Workload vulnerability summary](https://github.com/seebom-labs/seebom/issues/140) | Image → posture cross-reference for compliance dashboards. |
+| 🔲 | [#62 — Exportable Auditor Reports](https://github.com/seebom-labs/seebom/issues/62) | PDF/CSV compliance exports for CRA audits. |
+| 🔲 | [#60 — Local OSV Mirror](https://github.com/seebom-labs/seebom/issues/60) | Clone osv.dev into ClickHouse — offline, no rate limits. |
+| 🔲 | [#57 — Per-project license policies](https://github.com/seebom-labs/seebom/issues/57) | Scoped compliance rules for different product lines. |
+| 🔲 | [#143 — In-toto Witness Integration](https://github.com/seebom-labs/seebom/issues/143) | Supply chain attestation verification + provenance display. |
+| 🔲 | [#58 — Aggregated SBOM View](https://github.com/seebom-labs/seebom/issues/58) | Group version history under project names. |
+
+**Exit criteria:** Multi-cluster management with namespace isolation, SBOM push from CI/CD, PDF compliance reports, attestation verification, no external OSV dependency.
+
+---
+
+## 🎯 v1.0.0 Milestone {#v1}
+
+**Target: October 2026** · [GitHub Milestone →](https://github.com/seebom-labs/seebom/milestone/1)
+
+After Phase 2 completes, SeeBOM reaches **v1.0.0** — the first stable release. From this point forward, the [Support Policy](/docs/release/#support-policy) (current − 2) takes effect and breaking changes require a major version bump.
+
+### v1.0 Criteria
+
+| Requirement | Status | Issue |
+|-------------|:------:|-------|
+| API Authentication (service token + API key) | 🔲 | [#134](https://github.com/seebom-labs/seebom/issues/134) |
+| Cluster-aware data model (schema stable) | 🔲 | [#131](https://github.com/seebom-labs/seebom/issues/131) |
+| Cluster listing + detail endpoints | 🔲 | [#132](https://github.com/seebom-labs/seebom/issues/132), [#133](https://github.com/seebom-labs/seebom/issues/133) |
+| Namespace filtering | 🔲 | [#138](https://github.com/seebom-labs/seebom/issues/138) |
+| SBOM Upload endpoint | 🔲 | [#135](https://github.com/seebom-labs/seebom/issues/135) |
+| CycloneDX parsing | 🔲 | [#55](https://github.com/seebom-labs/seebom/issues/55) |
+| Enhanced health probes | 🔲 | [#137](https://github.com/seebom-labs/seebom/issues/137) |
+| Versioned documentation | 🔲 | [#145](https://github.com/seebom-labs/seebom/issues/145) |
+| Version Skew Detection | ✅ | [~~#37~~](https://github.com/seebom-labs/seebom/issues/37) |
+
+### What v1.0 means
+
+- **API contract frozen** — no endpoint removals or response shape changes without v2.0
+- **ClickHouse schema stable** — no ORDER BY or column type changes without migration tooling
+- **Helm values stable** — existing `values.yaml` keys won't be renamed
+- **Support policy active** — current release + 2 previous minors receive security patches
+- **SemVer enforced** — features in minor bumps, fixes in patches, breaking = major
+
+### Pre-1.0 releases
+
+All v0.x releases are development milestones. They may contain breaking changes between any minor version. Do not assume backward compatibility.
+
+---
+
+## Phase 3: Analytics & Compliance {#phase-3}
+
+**Q3 2026 (Oct–Dec) · Theme:** Advanced analytics, regulatory compliance scoring, and supply chain intelligence.
+
+| Status | Issue | Description |
+|:------:|-------|-------------|
+| 🔲 | [#141 — CRA Compliance Dashboard](https://github.com/seebom-labs/seebom/issues/141) | EU Cyber Resilience Act readiness scoring. |
+| 🔲 | [#38 — SBOM Diff](https://github.com/seebom-labs/seebom/issues/38) | Dependency tree divergence between versions. |
+| 🔲 | [#56 — Dependency Tree View](https://github.com/seebom-labs/seebom/issues/56) | Hierarchical visualization of transitive chains. |
+| 🔲 | [#63 — Blast Radius Search](https://github.com/seebom-labs/seebom/issues/63) | Version-constrained impact analysis with vuln context. |
+| 🔲 | [#64 — EPSS Scores](https://github.com/seebom-labs/seebom/issues/64) | Exploit probability scoring for prioritization. |
+| 🔲 | [#61 — OpenSSF Scorecard](https://github.com/seebom-labs/seebom/issues/61) | Upstream project health scoring per dependency. |
+| 🔲 | [#82 — Lottery Factor](https://github.com/seebom-labs/seebom/issues/82) | Single-maintainer risk detection. |
+| 🔲 | [#7 — CVE Fix Time (MTTR)](https://github.com/seebom-labs/seebom/issues/7) | Mean-time-to-remediate tracking per project. |
+
+**Exit criteria:** CRA readiness scoring, EPSS-based prioritization, dependency health metrics, and SBOM diff.
+
+---
+
+## Dependency Graph
+
+The following diagram shows blocking dependencies between issues:
+
+```text
+#131 (Cluster Model) ─────┬── #132 (Cluster Listing)
+                          ├── #133 (Cluster Detail)
+                          ├── #138 (Namespace) ── #140 (Workload Summary) ── #141 (CRA)
+                          └── #135 (Upload)
+                                    ↑
+#134 (Auth) ──────────────────────────┘
+#136 (CORS) ──────────────────────────┘
+
+#143 (Witness) ── standalone (feeds into #141 CRA Dashboard)
+#55 (CycloneDX) ── standalone
+#144 (SBOM Download) ── standalone
+#137 (Health Checks) ── standalone
+#139 (Headless Mode) ── standalone
+#60 (OSV Mirror) ── standalone
+#64 (EPSS) ── standalone (extends cve-refresher)
+#82 (Lottery Factor) ── extends internal/github
+#61 (Scorecard) ── extends internal/github
+```
+
+Key insight: **#131 (Cluster Model)** and **#134 (Auth)** are the critical-path items — most Phase 2 features depend on them.
+
+---
+
+## Success Metrics
+
+| Phase | Metric | Target |
+|-------|--------|--------|
+| Phase 1 | Production deployment with auth | Service token + API key working, health probes passing |
+| Phase 2 | CI/CD push integration | Upload endpoint processes 100 SBOMs/hour |
+| Phase 3 | CRA compliance readiness | All 5 CRA conditions evaluable, score >80% |
+
+---
+
+## Prioritization Philosophy
+
+### Multi-cluster before analytics
+Organizations evaluating SeeBOM for production ask *"Can it handle our 5 clusters?"* before *"Does it have EPSS scores?"*
+
+### Auth before upload
+A write endpoint without authentication is a security incident. Auth gates all write operations.
+
+### CRA compliance in Q3
+EU CRA enforcement begins 2027. Landing scoring by end of 2026 gives adopters a full year of runway.
+
+### Data enrichment as a batch
+EPSS, Scorecard, and Lottery Factor share the same architecture pattern (fetch → store → expose → display). Implementing them together maximizes code reuse.
+
+---
+
+## Non-Goals
+
+These items are **explicitly out of scope** for this roadmap:
+
+- ❌ Custom Kubernetes Operator (we use Helm + ClickHouse Operator)
+- ❌ Write APIs for license exceptions (frontend is public)
+- ❌ Multi-repo split (monorepo is a hard constraint)
+- ❌ Real-time streaming (batch ingestion is sufficient)
+- ❌ RBAC/multi-tenancy (auth is binary for now)
+- ❌ Full OIDC in SeeBOM (upstream proxy responsibility)
+
+---
+
+## Contributing
+
+Want to pick up an issue from the roadmap? Check the [Project Board](https://github.com/orgs/seebom-labs/projects/1) for items in the **Todo** column. Issues labeled `help wanted` are especially good for new contributors.
+
+See [Development Guide](/docs/development/) for setup instructions.
+
+

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -77,6 +77,11 @@ enableGitInfo = false
     url = "/docs/release/"
     identifier = "release"
   [[menu.main]]
+    name = "Roadmap"
+    weight = 65
+    url = "/docs/roadmap/"
+    identifier = "roadmap"
+  [[menu.main]]
     name = "FAQ"
     weight = 70
     url = "/docs/faq/"


### PR DESCRIPTION
## Description
Add comprehensive API reference documentation for headless/CI/CD consumers, formalize the release process with checklists for minor releases (including mandatory ROADMAP.md updates), and document the major version philosophy (2-3 year cadence, migration guide requirements).
This prepares SeeBOM for headless mode (#139) by ensuring API consumers have complete, standalone documentation without needing the UI.
## Type of Change
- [x] 📝 Documentation update
## Component(s) Affected
- [ ] API Gateway
- [ ] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [ ] Helm Chart
- [x] Documentation
## Related Issues
Relates to #139 (Headless mode)
Relates to #145 (Versioned docs)
## How Has This Been Tested?
- [ ] `go test ./...` passes
- [ ] `ng build` passes
- [ ] `helm lint` passes
- [x] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes
Documentation-only change — verified markdown renders correctly.
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)
## Changes Summary
**New files:**
- `docs/content/docs/api-reference/_index.md` — Full API reference (19 endpoints, examples, pagination, errors, headless mode, curl/CI examples)
**Updated files:**
- `docs/content/docs/release/_index.md` — Minor Release Checklist + Major Version Philosophy section
- `AGENTS.md` — Boundaries updated (ROADMAP.md requirement, major version constraint) + Major Version Policy section
- `README.md` — Fixed API endpoint table (version-skew params, search params, pagination), added API reference link