### PR TITLE
feat(#131): cluster-aware data model with per-bucket assignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Key shared packages:
 - `internal/osvutil` – Shared OSV helpers (ClassifySeverity, ExtractFixedVersion, ExtractAffectedVersions)
 - `internal/license` – License compliance + externalized policy + exceptions with prefix-matching
 - `internal/osv` – OSV API client with rate limiting and exponential backoff
-- `internal/s3` – S3-compatible bucket client (AWS S3, MinIO, GCS) for streaming SBOM ingestion from multiple buckets
+- `internal/s3` – S3-compatible bucket client (AWS S3, MinIO, GCS) for streaming SBOM ingestion from multiple buckets. Supports per-bucket `cluster` assignment for multi-cluster differentiation from a single instance.
 - `internal/github` – GitHub API client for resolving unknown licenses from PURL (rate-limited, cached). Includes 50+ well-known Go module→GitHub repo mappings (`golang.org/x/*`, `gopkg.in/*`, `go.uber.org/*`, `k8s.io/*`, `oras.land/*`, `dario.cat/*`, etc.), fallback to the dedicated `/repos/{owner}/{repo}/license` endpoint, and static license overrides for repos where GitHub misdetects the license.
 - `internal/spdx` – SPDX JSON streaming parser. Supports both plain SPDX documents and **in-toto attestation envelopes** where the SPDX content is wrapped inside the `predicate` field (common with Syft/BuildKit-generated container SBOMs).
 - `internal/vex` – OpenVEX parser with URL normalization
@@ -116,7 +116,7 @@ Frontend Test:   cd ui && npx ng test            # uses Vitest
 - When designing schemas, ensure the ORDER BY clause starts with low-cardinality columns (e.g., timestamp, category) to minimize data scanning and optimize performance.
 - Extract frequently queried JSON keys into top-level columns rather than relying entirely on generic Map or String types.
 - Avoid single-row inserts; always aggregate and batch inserts in Go.
-- Current tables: `sboms`, `sbom_packages`, `vulnerabilities`, `license_compliance`, `ingestion_queue`, `dashboard_stats_mv`, `vex_statements`, `cve_refresh_log`, `github_license_cache`, `github_repo_metadata` (11 migrations in `db/migrations/`).
+- Current tables: `sboms`, `sbom_packages`, `vulnerabilities`, `license_compliance`, `ingestion_queue`, `dashboard_stats_mv`, `vex_statements`, `cve_refresh_log`, `github_license_cache`, `github_repo_metadata` (12 migrations in `db/migrations/`). All core tables include a `cluster LowCardinality(String) DEFAULT ''` column for multi-cluster support.
 
 ## Angular (Frontend)
 - Use strict TypeScript mode and standalone components.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ cp .env.example .env
 | `SKIP_OSV` | `false` | Skip OSV vulnerability API calls. Set `true` for fast initial bulk load (licenses only), then re-run with `false`. |
 | `SKIP_GITHUB_RESOLVE` | `false` | Skip GitHub license resolution for packages with `NOASSERTION`/empty licenses. |
 | `GITHUB_TOKEN` | *(empty)* | GitHub personal access token for license resolution. Increases rate limit from 60 to 5000 req/h. No scopes needed. |
+| `CLUSTER_NAME` | *(empty)* | Cluster identifier for multi-cluster deployments. All ingested data is tagged with this value. Empty = single-instance mode. |
 | `CUSTOM_THEME` | (example file) | Path to a custom CSS theme file for the UI. See "Custom Theme" section. |
 | `UI_CONFIG` | `./ui/public/ui-config.json` | Path to a JSON file with UI text overrides (brand name, dashboard texts, disclaimer). See "Site Configuration" section. |
-| `S3_BUCKETS` | *(empty)* | JSON array of S3 bucket configs. See "S3 Ingestion" section. |
+| `S3_BUCKETS` | *(empty)* | JSON array of S3 bucket configs (supports per-bucket `cluster` override). See "S3 Ingestion" section. |
 | `S3_BUCKET` | *(empty)* | Single S3 bucket name (simpler alternative to `S3_BUCKETS`). |
 | `S3_ENDPOINT` | `s3.amazonaws.com` | S3 endpoint URL. |
 | `S3_REGION` | `us-east-1` | AWS region. |
@@ -236,6 +237,20 @@ S3_BUCKETS='[{"name":"my-private-bucket"}]'
 # Or per-bucket credentials in JSON:
 S3_BUCKETS='[{"name":"my-bucket","accessKey":"AKIA...","secretKey":"..."}]'
 ```
+
+**Multi-cluster: per-bucket cluster assignment:**
+
+```bash
+# .env — each bucket maps to a different cluster
+CLUSTER_NAME=default
+S3_BUCKETS='[
+  {"name":"prod-eu-sboms", "cluster":"prod-eu", "region":"eu-west-1"},
+  {"name":"prod-us-sboms", "cluster":"prod-us", "region":"us-east-1"},
+  {"name":"staging-sboms", "cluster":"staging"}
+]'
+```
+
+Buckets without a `cluster` field inherit the global `CLUSTER_NAME`. If neither is set, data is untagged (single-instance mode).
 
 **How it works:**
 - The Ingestion Watcher streams `ListObjects` from each bucket (paginated, no full listing in memory)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # SeeBOM Product Roadmap
 
-> Last updated: 2026-05-21
+> Last updated: 2026-05-22
 > Project Board: https://github.com/orgs/seebom-labs/projects/1
 
 ## Executive Summary
@@ -45,9 +45,9 @@ The sequencing is driven by dependency chains: multi-cluster support must land b
 | #140 | Workload vulnerability summary | The key cross-reference: image → posture. Powers compliance dashboards. |
 | #62 | Exportable Auditor Reports (PDF/CSV) | CRA compliance requires offline documentation. Auditors don't use UIs. |
 | #60 | Local OSV Mirror | Eliminates external dependency on osv.dev. Faster scans, offline capability, no rate limits. |
-| #57 | Per-project license policies | Enterprise reality: different products have different license constraints. |
+| #57 | Project-aware data model + per-project policies | **Expanded scope.** Add `project LowCardinality(String) DEFAULT ''` column to all core tables (same pattern as `cluster`). Resolution via per-bucket config, push API payload, or document-name convention. Includes per-project license policies, severity thresholds, and exception scopes. Powers Project List View (#8) and Aggregated SBOM View (#58). |
 | #143 | In-toto Witness Integration | Supply chain attestation verification for ingested SBOMs. Provenance display, signature verification. Prerequisite for CRA compliance scoring (#141). |
-| #58 | Aggregated SBOM View | UX fix: group 50 versions of containerd into one expandable row. |
+| #58 | Aggregated SBOM View | UX fix: group 50 versions of containerd into one expandable row. Depends on project-aware data model (#57). |
 
 **Exit criteria:** SeeBOM manages multiple clusters with namespace isolation, accepts SBOM pushes from CI/CD, generates PDF compliance reports, attestation verification, and doesn't depend on external OSV availability.
 
@@ -103,6 +103,10 @@ After Phase 2 completes, SeeBOM reaches **v1.0.0** — the first stable release:
 #134 (Auth) ──────────────────────────┘
 #136 (CORS) ──────────────────────────┘
 
+#57 (Project Model) ──────┬── #8  (Project List View)
+                          ├── #58 (Aggregated SBOM View)
+                          └── Per-project policies (license, severity, exceptions)
+
 #143 (Witness) ── standalone (feeds into #141 CRA Dashboard)
 #55 (CycloneDX) ── standalone
 #144 (SBOM Download) ── standalone
@@ -133,6 +137,22 @@ The EU Cyber Resilience Act enforcement begins 2027. Organizations need 6-12 mon
 ### Why EPSS/Scorecard/Lottery Factor together?
 
 These are all "data enrichment" features that follow the same pattern: fetch external data → store in ClickHouse → expose via API → display in frontend. Implementing them as a batch maximizes code reuse and architectural consistency.
+
+### Why project model is separate from cluster model?
+
+**Cluster** and **project** are orthogonal dimensions:
+
+| Dimension | Cluster | Project |
+|-----------|---------|---------|
+| Question answered | Where is it deployed? | What is it / who owns it? |
+| Example | `prod-eu`, `staging-us` | `payment-service`, `mobile-app` |
+| Cardinality | Low (1-50) | High (50-5000) |
+| Ownership | Platform team | Dev teams |
+| Lifecycle | Stable (years) | Volatile |
+
+A single SBOM can simultaneously belong to cluster `prod-eu` AND project `payment-service`. We model these as independent low-cardinality columns rather than overloading one field.
+
+Cluster lands first (Phase 1, #131) because it's a smaller change with no UI implications. Project (#57) lands in Phase 2 because it requires UI work (project picker, per-project dashboards) and benefits from the Upload endpoint (#135) where the client can declare the project at push time.
 
 ---
 

--- a/backend/cmd/ingestion-watcher/main.go
+++ b/backend/cmd/ingestion-watcher/main.go
@@ -116,6 +116,7 @@ func ingestLocalFiles(ctx context.Context, cfg *config.Config, chClient *clickho
 			SHA256Hash: f.SHA256Hash,
 			Status:     models.JobStatusPending,
 			JobType:    jobType,
+			Cluster:    cfg.ClusterName,
 		})
 
 		// Flush batch when it reaches the threshold.
@@ -150,6 +151,8 @@ func ingestLocalFiles(ctx context.Context, cfg *config.Config, chClient *clickho
 func ingestS3Buckets(ctx context.Context, cfg *config.Config, chClient *clickhouse.Client, sbomCount *int) int {
 	// Convert config bucket types to s3 package types.
 	bucketConfigs := make([]s3client.BucketConfig, len(cfg.S3Buckets))
+	// Build bucket→cluster mapping: per-bucket cluster overrides global ClusterName.
+	bucketCluster := make(map[string]string, len(cfg.S3Buckets))
 	for i, b := range cfg.S3Buckets {
 		bucketConfigs[i] = s3client.BucketConfig{
 			Name:         b.Name,
@@ -160,6 +163,11 @@ func ingestS3Buckets(ctx context.Context, cfg *config.Config, chClient *clickhou
 			Prefix:       b.Prefix,
 			UsePathStyle: b.UsePathStyle,
 			UseSSL:       b.UseSSL,
+		}
+		if b.Cluster != "" {
+			bucketCluster[b.Name] = b.Cluster
+		} else {
+			bucketCluster[b.Name] = cfg.ClusterName
 		}
 	}
 
@@ -218,6 +226,7 @@ func ingestS3Buckets(ctx context.Context, cfg *config.Config, chClient *clickhou
 			SHA256Hash: obj.ETag, // Use ETag for dedup (no download needed during listing)
 			Status:     models.JobStatusPending,
 			JobType:    jobType,
+			Cluster:    bucketCluster[obj.Bucket],
 		})
 
 		// Flush batch.

--- a/backend/cmd/parsing-worker/main.go
+++ b/backend/cmd/parsing-worker/main.go
@@ -288,11 +288,13 @@ func processSBOMJob(ctx context.Context, cfg *config.Config, chClient *clickhous
 	}
 
 	// 3. Insert SBOM metadata.
+	result.SBOM.Cluster = job.Cluster
 	if err := chClient.InsertSBOM(ctx, &result.SBOM); err != nil {
 		return err
 	}
 
 	// 4. Insert package arrays (with resolved licenses).
+	result.Packages.Cluster = job.Cluster
 	if err := chClient.InsertSBOMPackages(ctx, &result.Packages); err != nil {
 		return err
 	}
@@ -388,6 +390,7 @@ func processSBOMJob(ctx context.Context, cfg *config.Config, chClient *clickhous
 						AffectedVersions: affectedVersions,
 						FixedVersion:     fixedVersion,
 						OSVJSON:          string(rawJSON),
+						Cluster:          job.Cluster,
 					})
 				}
 			}
@@ -424,6 +427,7 @@ func processSBOMJob(ctx context.Context, cfg *config.Config, chClient *clickhous
 				NonCompliantPackages: nonCompliant,
 				ExemptedPackages:     exempted,
 				ExemptionReason:      lr.ExemptionReason,
+				Cluster:              job.Cluster,
 			}
 		}
 		if err := chClient.InsertLicenseCompliance(ctx, licModels); err != nil {

--- a/backend/internal/clickhouse/insert.go
+++ b/backend/internal/clickhouse/insert.go
@@ -14,7 +14,7 @@ func (c *Client) InsertSBOM(ctx context.Context, sbom *models.SBOM) error {
 		`INSERT INTO sboms (
 			ingested_at, sbom_id, source_file, spdx_version,
 			document_name, document_namespace, sha256_hash,
-			creation_date, creator_tools
+			creation_date, creator_tools, cluster
 		)`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare sbom batch: %w", err)
@@ -30,6 +30,7 @@ func (c *Client) InsertSBOM(ctx context.Context, sbom *models.SBOM) error {
 		sbom.SHA256Hash,
 		sbom.CreationDate,
 		sbom.CreatorTools,
+		sbom.Cluster,
 	); err != nil {
 		return fmt.Errorf("failed to append sbom: %w", err)
 	}
@@ -44,7 +45,7 @@ func (c *Client) InsertSBOMPackages(ctx context.Context, pkg *models.SBOMPackage
 			ingested_at, sbom_id, source_file,
 			package_spdx_ids, package_names, package_versions,
 			package_purls, package_licenses,
-			rel_source_indices, rel_target_indices, rel_types
+			rel_source_indices, rel_target_indices, rel_types, cluster
 		)`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare sbom_packages batch: %w", err)
@@ -62,6 +63,7 @@ func (c *Client) InsertSBOMPackages(ctx context.Context, pkg *models.SBOMPackage
 		pkg.RelSourceIndices,
 		pkg.RelTargetIndices,
 		pkg.RelTypes,
+		pkg.Cluster,
 	); err != nil {
 		return fmt.Errorf("failed to append sbom_packages: %w", err)
 	}
@@ -78,7 +80,7 @@ func (c *Client) InsertVulnerabilities(ctx context.Context, vulns []models.Vulne
 	batch, err := c.Conn.PrepareBatch(ctx,
 		`INSERT INTO vulnerabilities (
 			discovered_at, sbom_id, source_file, purl, vuln_id,
-			severity, summary, affected_versions, fixed_version, osv_json
+			severity, summary, affected_versions, fixed_version, osv_json, cluster
 		)`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare vulnerabilities batch: %w", err)
@@ -96,6 +98,7 @@ func (c *Client) InsertVulnerabilities(ctx context.Context, vulns []models.Vulne
 			v.AffectedVersions,
 			v.FixedVersion,
 			v.OSVJSON,
+			v.Cluster,
 		); err != nil {
 			return fmt.Errorf("failed to append vulnerability %s: %w", v.VulnID, err)
 		}
@@ -114,7 +117,7 @@ func (c *Client) InsertLicenseCompliance(ctx context.Context, items []models.Lic
 		`INSERT INTO license_compliance (
 			checked_at, sbom_id, source_file, license_id,
 			category, package_count, non_compliant_packages,
-			exempted_packages, exemption_reason
+			exempted_packages, exemption_reason, cluster
 		)`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare license_compliance batch: %w", err)
@@ -136,6 +139,7 @@ func (c *Client) InsertLicenseCompliance(ctx context.Context, items []models.Lic
 			item.NonCompliantPackages,
 			exempted,
 			item.ExemptionReason,
+			item.Cluster,
 		); err != nil {
 			return fmt.Errorf("failed to append license_compliance: %w", err)
 		}
@@ -154,7 +158,7 @@ func (c *Client) InsertVEXStatements(ctx context.Context, stmts []models.VEXStat
 		`INSERT INTO vex_statements (
 			ingested_at, vex_id, document_id, source_file,
 			product_purl, vuln_id, status, justification,
-			impact_statement, action_statement, vex_timestamp
+			impact_statement, action_statement, vex_timestamp, cluster
 		)`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare vex_statements batch: %w", err)
@@ -173,6 +177,7 @@ func (c *Client) InsertVEXStatements(ctx context.Context, stmts []models.VEXStat
 			s.ImpactStatement,
 			s.ActionStatement,
 			s.VEXTimestamp,
+			s.Cluster,
 		); err != nil {
 			return fmt.Errorf("failed to append vex_statement: %w", err)
 		}

--- a/backend/internal/clickhouse/queue.go
+++ b/backend/internal/clickhouse/queue.go
@@ -15,7 +15,7 @@ func (c *Client) EnqueueJobs(ctx context.Context, jobs []models.IngestionJob) er
 	}
 
 	batch, err := c.Conn.PrepareBatch(ctx,
-		"INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message)")
+		"INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message, cluster)")
 	if err != nil {
 		return fmt.Errorf("failed to prepare queue batch: %w", err)
 	}
@@ -36,6 +36,7 @@ func (c *Client) EnqueueJobs(ctx context.Context, jobs []models.IngestionJob) er
 			(*time.Time)(nil),
 			(*time.Time)(nil),
 			"",
+			job.Cluster,
 		); err != nil {
 			return fmt.Errorf("failed to append queue job: %w", err)
 		}
@@ -53,7 +54,7 @@ func (c *Client) EnqueueJobs(ctx context.Context, jobs []models.IngestionJob) er
 // regardless of merge timing. This avoids phantom re-claims entirely.
 func (c *Client) ClaimJobs(ctx context.Context, workerID string, limit int) ([]models.IngestionJob, error) {
 	rows, err := c.Conn.Query(ctx, `
-		SELECT job_id, source_file, sha256_hash, min_created, job_type
+		SELECT job_id, source_file, sha256_hash, min_created, job_type, cluster
 		FROM (
 		    SELECT
 		        job_id,
@@ -61,7 +62,8 @@ func (c *Client) ClaimJobs(ctx context.Context, workerID string, limit int) ([]m
 		        argMax(sha256_hash, created_at)  AS sha256_hash,
 		        min(created_at)                  AS min_created,
 		        argMax(job_type, created_at)      AS job_type,
-		        argMax(status, created_at)        AS latest_status
+		        argMax(status, created_at)        AS latest_status,
+		        argMax(cluster, created_at)       AS cluster
 		    FROM ingestion_queue
 		    GROUP BY job_id
 		) sub
@@ -76,7 +78,7 @@ func (c *Client) ClaimJobs(ctx context.Context, workerID string, limit int) ([]m
 	var jobs []models.IngestionJob
 	for rows.Next() {
 		var job models.IngestionJob
-		if err := rows.Scan(&job.JobID, &job.SourceFile, &job.SHA256Hash, &job.CreatedAt, &job.JobType); err != nil {
+		if err := rows.Scan(&job.JobID, &job.SourceFile, &job.SHA256Hash, &job.CreatedAt, &job.JobType, &job.Cluster); err != nil {
 			return nil, fmt.Errorf("failed to scan job row: %w", err)
 		}
 		job.Status = models.JobStatusProcessing
@@ -92,7 +94,7 @@ func (c *Client) ClaimJobs(ctx context.Context, workerID string, limit int) ([]m
 
 	// Mark claimed jobs as processing.
 	batch, err := c.Conn.PrepareBatch(ctx,
-		"INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message)")
+		"INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message, cluster)")
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare claim batch: %w", err)
 	}
@@ -109,6 +111,7 @@ func (c *Client) ClaimJobs(ctx context.Context, workerID string, limit int) ([]m
 			job.ClaimedAt,
 			(*time.Time)(nil),
 			"",
+			job.Cluster,
 		); err != nil {
 			return nil, fmt.Errorf("failed to append claim: %w", err)
 		}
@@ -125,16 +128,16 @@ func (c *Client) ClaimJobs(ctx context.Context, workerID string, limit int) ([]m
 func (c *Client) CompleteJob(ctx context.Context, job models.IngestionJob) error {
 	now := time.Now()
 	return c.Conn.Exec(ctx,
-		`INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		now, job.JobID, job.SourceFile, job.SHA256Hash, models.JobStatusDone, job.JobType, job.ClaimedBy, job.ClaimedAt, &now, "")
+		`INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message, cluster)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		now, job.JobID, job.SourceFile, job.SHA256Hash, models.JobStatusDone, job.JobType, job.ClaimedBy, job.ClaimedAt, &now, "", job.Cluster)
 }
 
 // FailJob marks a job as failed with an error message.
 func (c *Client) FailJob(ctx context.Context, job models.IngestionJob, errMsg string) error {
 	now := time.Now()
 	return c.Conn.Exec(ctx,
-		`INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		now, job.JobID, job.SourceFile, job.SHA256Hash, models.JobStatusFailed, job.JobType, job.ClaimedBy, job.ClaimedAt, &now, errMsg)
+		`INSERT INTO ingestion_queue (created_at, job_id, source_file, sha256_hash, status, job_type, claimed_by, claimed_at, finished_at, error_message, cluster)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		now, job.JobID, job.SourceFile, job.SHA256Hash, models.JobStatusFailed, job.JobType, job.ClaimedBy, job.ClaimedAt, &now, errMsg, job.Cluster)
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -18,6 +18,7 @@ type S3BucketConfig struct {
 	Prefix       string `json:"prefix"`
 	UsePathStyle bool   `json:"usePathStyle"`
 	UseSSL       *bool  `json:"useSSL"`
+	Cluster      string `json:"cluster"` // Optional: override ClusterName for this bucket
 }
 
 // Config holds all configuration values, read from environment variables.
@@ -50,6 +51,9 @@ type Config struct {
 	ExceptionsFile    string // Path to license-exceptions.json
 	LicensePolicyFile string // Path to license-policy.json
 	GitHubToken       string // GitHub personal access token (optional, increases rate limit)
+
+	// Multi-cluster
+	ClusterName string // Cluster identifier for this instance (default "" = unassigned)
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -71,6 +75,7 @@ func Load() (*Config, error) {
 		ExceptionsFile:     getEnv("EXCEPTIONS_FILE", "/data/config/license-exceptions.json"),
 		LicensePolicyFile:  getEnv("LICENSE_POLICY_FILE", "/data/config/license-policy.json"),
 		GitHubToken:        getEnv("GITHUB_TOKEN", ""),
+		ClusterName:        getEnv("CLUSTER_NAME", ""),
 	}
 
 	if cfg.WorkerID == "" {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -221,3 +221,61 @@ func TestS3BucketNames(t *testing.T) {
 		t.Errorf("S3BucketNames() = %q, want %q", got, "bucket-a/v1/, bucket-b")
 	}
 }
+
+func TestLoad_ClusterName_Default(t *testing.T) {
+	os.Unsetenv("CLUSTER_NAME")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.ClusterName != "" {
+		t.Errorf("expected default ClusterName=\"\", got %q", cfg.ClusterName)
+	}
+}
+
+func TestLoad_ClusterName_Custom(t *testing.T) {
+	t.Setenv("CLUSTER_NAME", "production-eu-west-1")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.ClusterName != "production-eu-west-1" {
+		t.Errorf("expected ClusterName=\"production-eu-west-1\", got %q", cfg.ClusterName)
+	}
+}
+
+func TestLoad_S3BucketClusterOverride(t *testing.T) {
+	t.Setenv("S3_BUCKETS", `[{"name":"prod-bucket","cluster":"prod-eu"},{"name":"staging-bucket","cluster":"staging"},{"name":"default-bucket"}]`)
+	t.Setenv("CLUSTER_NAME", "global-fallback")
+	os.Unsetenv("S3_BUCKET")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if len(cfg.S3Buckets) != 3 {
+		t.Fatalf("expected 3 buckets, got %d", len(cfg.S3Buckets))
+	}
+
+	// Bucket with explicit cluster.
+	if cfg.S3Buckets[0].Cluster != "prod-eu" {
+		t.Errorf("bucket[0].Cluster = %q, want \"prod-eu\"", cfg.S3Buckets[0].Cluster)
+	}
+	if cfg.S3Buckets[1].Cluster != "staging" {
+		t.Errorf("bucket[1].Cluster = %q, want \"staging\"", cfg.S3Buckets[1].Cluster)
+	}
+	// Bucket without cluster — stays empty (watcher resolves to ClusterName at runtime).
+	if cfg.S3Buckets[2].Cluster != "" {
+		t.Errorf("bucket[2].Cluster = %q, want \"\" (empty, fallback to ClusterName)", cfg.S3Buckets[2].Cluster)
+	}
+
+	// Global ClusterName is the fallback.
+	if cfg.ClusterName != "global-fallback" {
+		t.Errorf("ClusterName = %q, want \"global-fallback\"", cfg.ClusterName)
+	}
+}

--- a/backend/pkg/models/models_test.go
+++ b/backend/pkg/models/models_test.go
@@ -1,0 +1,117 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestSBOM_ClusterField(t *testing.T) {
+	sbom := SBOM{
+		IngestedAt:   time.Now(),
+		SBOMID:       uuid.New(),
+		SourceFile:   "test.spdx.json",
+		DocumentName: "test-doc",
+		Cluster:      "prod-eu-1",
+	}
+
+	if sbom.Cluster != "prod-eu-1" {
+		t.Errorf("expected Cluster=\"prod-eu-1\", got %q", sbom.Cluster)
+	}
+
+	// Verify JSON serialization includes cluster.
+	data, err := json.Marshal(sbom)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if m["cluster"] != "prod-eu-1" {
+		t.Errorf("JSON cluster field = %v, want \"prod-eu-1\"", m["cluster"])
+	}
+}
+
+func TestSBOM_ClusterOmitEmpty(t *testing.T) {
+	sbom := SBOM{
+		IngestedAt:   time.Now(),
+		SBOMID:       uuid.New(),
+		SourceFile:   "test.spdx.json",
+		DocumentName: "test-doc",
+		Cluster:      "", // empty = default cluster
+	}
+
+	data, err := json.Marshal(sbom)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// With omitempty, empty cluster should not appear in JSON.
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if _, exists := m["cluster"]; exists {
+		t.Error("expected cluster to be omitted for empty value")
+	}
+}
+
+func TestIngestionJob_ClusterPropagation(t *testing.T) {
+	job := IngestionJob{
+		CreatedAt:  time.Now(),
+		JobID:      uuid.New(),
+		SourceFile: "s3://bucket/path.spdx.json",
+		SHA256Hash: "abc123",
+		Status:     JobStatusPending,
+		JobType:    JobTypeSBOM,
+		Cluster:    "staging-us-east",
+	}
+
+	if job.Cluster != "staging-us-east" {
+		t.Errorf("expected Cluster=\"staging-us-east\", got %q", job.Cluster)
+	}
+}
+
+func TestVulnerability_ClusterField(t *testing.T) {
+	vuln := Vulnerability{
+		DiscoveredAt: time.Now(),
+		SBOMID:       uuid.New(),
+		VulnID:       "CVE-2024-1234",
+		Cluster:      "prod-cluster",
+	}
+
+	if vuln.Cluster != "prod-cluster" {
+		t.Errorf("expected Cluster=\"prod-cluster\", got %q", vuln.Cluster)
+	}
+}
+
+func TestLicenseCompliance_ClusterField(t *testing.T) {
+	lc := LicenseCompliance{
+		CheckedAt: time.Now(),
+		SBOMID:    uuid.New(),
+		LicenseID: "MIT",
+		Category:  "permissive",
+		Cluster:   "dev-local",
+	}
+
+	if lc.Cluster != "dev-local" {
+		t.Errorf("expected Cluster=\"dev-local\", got %q", lc.Cluster)
+	}
+}
+
+func TestVEXStatement_ClusterField(t *testing.T) {
+	stmt := VEXStatement{
+		IngestedAt: time.Now(),
+		VEXID:      uuid.New(),
+		VulnID:     "CVE-2024-5678",
+		Status:     VEXStatusNotAffected,
+		Cluster:    "fleet-asia",
+	}
+
+	if stmt.Cluster != "fleet-asia" {
+		t.Errorf("expected Cluster=\"fleet-asia\", got %q", stmt.Cluster)
+	}
+}

--- a/backend/pkg/models/sbom.go
+++ b/backend/pkg/models/sbom.go
@@ -17,6 +17,7 @@ type SBOM struct {
 	SHA256Hash        string    `json:"sha256_hash"`
 	CreationDate      time.Time `json:"creation_date"`
 	CreatorTools      []string  `json:"creator_tools"`
+	Cluster           string    `json:"cluster,omitempty"`
 }
 
 // SBOMPackages stores the full dependency tree of an SBOM as parallel arrays.
@@ -33,6 +34,7 @@ type SBOMPackages struct {
 	RelSourceIndices []uint32  `json:"rel_source_indices"`
 	RelTargetIndices []uint32  `json:"rel_target_indices"`
 	RelTypes         []string  `json:"rel_types"`
+	Cluster          string    `json:"cluster,omitempty"`
 }
 
 // Vulnerability represents a single vulnerability discovered via the OSV API.
@@ -47,6 +49,7 @@ type Vulnerability struct {
 	AffectedVersions []string  `json:"affected_versions"`
 	FixedVersion     string    `json:"fixed_version"`
 	OSVJSON          string    `json:"osv_json"`
+	Cluster          string    `json:"cluster,omitempty"`
 }
 
 // LicenseCompliance represents the compliance status for a license within an SBOM.
@@ -60,6 +63,7 @@ type LicenseCompliance struct {
 	NonCompliantPackages []string  `json:"non_compliant_packages"`
 	ExemptedPackages     []string  `json:"exempted_packages"`
 	ExemptionReason      string    `json:"exemption_reason"`
+	Cluster              string    `json:"cluster,omitempty"`
 }
 
 // IngestionJob represents a job in the ClickHouse-based queue.
@@ -74,6 +78,7 @@ type IngestionJob struct {
 	ClaimedAt    *time.Time `json:"claimed_at,omitempty"`
 	FinishedAt   *time.Time `json:"finished_at,omitempty"`
 	ErrorMessage string     `json:"error_message,omitempty"`
+	Cluster      string     `json:"cluster,omitempty"`
 }
 
 // Job status constants.
@@ -103,6 +108,7 @@ type VEXStatement struct {
 	ImpactStatement string    `json:"impact_statement"`
 	ActionStatement string    `json:"action_statement"`
 	VEXTimestamp    time.Time `json:"vex_timestamp"`
+	Cluster         string    `json:"cluster,omitempty"`
 }
 
 // VEX status constants (OpenVEX spec).

--- a/db/migrations/012_add_cluster_column.up.sql
+++ b/db/migrations/012_add_cluster_column.up.sql
@@ -1,0 +1,12 @@
+-- Migration 012: Add cluster column to core tables for multi-cluster support.
+-- Non-destructive: existing data gets DEFAULT '' (unassigned/default cluster).
+-- Note: Cannot alter ORDER BY on existing MergeTree tables, so cluster is a
+-- regular column for now. A future breaking migration can optimize ORDER BY.
+
+ALTER TABLE sboms ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
+ALTER TABLE sbom_packages ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
+ALTER TABLE vulnerabilities ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
+ALTER TABLE license_compliance ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
+ALTER TABLE ingestion_queue ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
+ALTER TABLE vex_statements ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
+

--- a/docs/content/docs/architecture/_index.md
+++ b/docs/content/docs/architecture/_index.md
@@ -81,6 +81,58 @@ API Gateway (REST) → 19 Endpoints → Angular UI
 | `github_license_cache` | ReplacingMergeTree | Resolved GitHub licenses cache |
 | `github_repo_metadata` | ReplacingMergeTree | GitHub repo metadata (archived, fork, stars) |
 
+All core tables (`sboms`, `sbom_packages`, `vulnerabilities`, `license_compliance`, `ingestion_queue`, `vex_statements`) include a `cluster LowCardinality(String) DEFAULT ''` column for multi-cluster support.
+
+## Multi-Cluster Data Model
+
+SeeBOM supports tagging all ingested data with a **cluster identifier** for multi-cluster deployments. This is fully optional — single-instance deployments work without any configuration.
+
+### How it works
+
+```
+┌────────────────────────────────────┐
+│  S3 Buckets with per-bucket cluster │
+│                                      │
+│  bucket: prod-eu-sboms               │
+│  cluster: "prod-eu"                  │
+│                                      │
+│  bucket: staging-sboms               │
+│  cluster: "staging"                  │
+│                                      │
+│  bucket: other-sboms                 │
+│  cluster: "" (inherits CLUSTER_NAME) │
+└────────────────┬─────────────────────┘
+                 │
+                 ▼
+    Ingestion Watcher
+    (resolves cluster per object)
+                 │
+                 ▼
+    ingestion_queue.cluster = "prod-eu" | "staging" | ""
+                 │
+                 ▼
+    Parsing Worker
+    (propagates job.Cluster → all inserts)
+                 │
+                 ▼
+    sboms.cluster / vulnerabilities.cluster / etc.
+```
+
+### Configuration
+
+| Method | Use case |
+|--------|----------|
+| No config (default) | Single instance, no cluster differentiation |
+| `CLUSTER_NAME=prod-eu` | All data from this instance tagged as `prod-eu` |
+| Per-bucket `"cluster"` in `S3_BUCKETS` JSON | One watcher instance ingests from multiple clusters |
+| Mix: per-bucket + `CLUSTER_NAME` fallback | Buckets without explicit cluster inherit the global value |
+
+### Priority
+
+1. Per-bucket `cluster` field in S3 config (highest)
+2. Global `CLUSTER_NAME` environment variable (fallback)
+3. Empty string `""` (no cluster, single-instance mode)
+
 ## API Endpoints
 
 | Method | Endpoint | Description |

--- a/docs/content/docs/deployment/_index.md
+++ b/docs/content/docs/deployment/_index.md
@@ -96,6 +96,47 @@ s3:
 - Streams object listings — handles 100k+ SBOMs without memory issues
 - Works with any S3-compatible storage (AWS, GCS, MinIO, Ceph, DigitalOcean Spaces)
 
+### Multi-Cluster Ingestion
+
+SeeBOM supports tagging data by **cluster** for multi-cluster visibility from a single instance. This is fully optional — omit all cluster config for single-instance mode.
+
+**Option 1: Global cluster name (one instance per cluster)**
+
+```yaml
+# values-prod-eu.yaml
+ingestionWatcher:
+  env:
+    CLUSTER_NAME: "prod-eu"
+```
+
+Deploy one SeeBOM instance per cluster, each with its own `CLUSTER_NAME`.
+
+**Option 2: Per-bucket cluster assignment (one instance, multiple clusters)**
+
+```yaml
+# values.yaml — single watcher, multiple clusters
+ingestionWatcher:
+  env:
+    CLUSTER_NAME: "default"   # fallback for buckets without explicit cluster
+
+s3:
+  buckets: |
+    [
+      {"name": "prod-eu-sboms", "region": "eu-west-1", "cluster": "prod-eu"},
+      {"name": "prod-us-sboms", "region": "us-east-1", "cluster": "prod-us"},
+      {"name": "staging-sboms", "cluster": "staging"},
+      {"name": "shared-sboms"}
+    ]
+```
+
+In this example:
+- `prod-eu-sboms` → all SBOMs tagged as `prod-eu`
+- `prod-us-sboms` → tagged as `prod-us`
+- `staging-sboms` → tagged as `staging`
+- `shared-sboms` → inherits `CLUSTER_NAME` = `default`
+
+**Priority:** per-bucket `cluster` > global `CLUSTER_NAME` > empty (untagged)
+
 ### Option B: Seed Job
 
 ```yaml

--- a/docs/content/docs/roadmap/_index.md
+++ b/docs/content/docs/roadmap/_index.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 {{% alert title="Last Updated" color="info" %}}
-2026-05-21 · [Project Board →](https://github.com/orgs/seebom-labs/projects/1)
+2026-05-22 · [Project Board →](https://github.com/orgs/seebom-labs/projects/1)
 {{% /alert %}}
 
 ## Vision
@@ -55,9 +55,9 @@ SeeBOM is transitioning from a single-instance SBOM visualization tool into an *
 | 🔲 | [#140 — Workload vulnerability summary](https://github.com/seebom-labs/seebom/issues/140) | Image → posture cross-reference for compliance dashboards. |
 | 🔲 | [#62 — Exportable Auditor Reports](https://github.com/seebom-labs/seebom/issues/62) | PDF/CSV compliance exports for CRA audits. |
 | 🔲 | [#60 — Local OSV Mirror](https://github.com/seebom-labs/seebom/issues/60) | Clone osv.dev into ClickHouse — offline, no rate limits. |
-| 🔲 | [#57 — Per-project license policies](https://github.com/seebom-labs/seebom/issues/57) | Scoped compliance rules for different product lines. |
+| 🔲 | [#57 — Project-aware data model + per-project policies](https://github.com/seebom-labs/seebom/issues/57) | **Expanded scope.** Adds a `project` column to all core tables (same pattern as `cluster`), enabling per-project license policies, severity thresholds, and exception scopes. Powers Project List View (#8) and Aggregated SBOM View (#58). |
 | 🔲 | [#143 — In-toto Witness Integration](https://github.com/seebom-labs/seebom/issues/143) | Supply chain attestation verification + provenance display. |
-| 🔲 | [#58 — Aggregated SBOM View](https://github.com/seebom-labs/seebom/issues/58) | Group version history under project names. |
+| 🔲 | [#58 — Aggregated SBOM View](https://github.com/seebom-labs/seebom/issues/58) | Group version history under project names. Depends on #57. |
 
 **Exit criteria:** Multi-cluster management with namespace isolation, SBOM push from CI/CD, PDF compliance reports, attestation verification, no external OSV dependency.
 
@@ -129,6 +129,10 @@ The following diagram shows blocking dependencies between issues:
 #134 (Auth) ──────────────────────────┘
 #136 (CORS) ──────────────────────────┘
 
+#57 (Project Model) ──────┬── #8  (Project List View)
+                          ├── #58 (Aggregated SBOM View)
+                          └── Per-project policies (license, severity, exceptions)
+
 #143 (Witness) ── standalone (feeds into #141 CRA Dashboard)
 #55 (CycloneDX) ── standalone
 #144 (SBOM Download) ── standalone
@@ -140,7 +144,7 @@ The following diagram shows blocking dependencies between issues:
 #61 (Scorecard) ── extends internal/github
 ```
 
-Key insight: **#131 (Cluster Model)** and **#134 (Auth)** are the critical-path items — most Phase 2 features depend on them.
+Key insight: **#131 (Cluster Model)**, **#134 (Auth)**, and **#57 (Project Model)** are the critical-path items — most Phase 2 features depend on them. Cluster and project are orthogonal dimensions (infrastructure vs. ownership) and intentionally modeled as separate low-cardinality columns.
 
 ---
 


### PR DESCRIPTION
## Description
Implements **#131 — Cluster-aware data model**, the foundational multi-cluster schema change that unblocks all Phase 2 multi-cluster features (#132, #133, #135, #138).
The feature is **fully optional and backward compatible** — single-instance deployments require zero configuration changes. Existing data gets `cluster = ""` via `DEFAULT` and continues to work unchanged.
## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Infrastructure / CI / Helm (schema migration)
- [x] 📝 Documentation update
## Component(s) Affected
- [x] API Gateway (model structs)
- [x] Parsing Worker (cluster propagation)
- [x] Ingestion Watcher (cluster resolution)
- [x] ClickHouse Schema / Migrations (migration 012)
- [ ] Angular UI (next PR, requires #132 cluster listing endpoint first)
- [ ] Helm Chart
- [x] Documentation
## Related Issues
Closes #131
Relates to #57 (scope expanded to project-aware data model in this PR)
Unblocks #132, #133, #135, #138
## How It Works
### Resolution priority (highest → lowest)
1. **Per-bucket `cluster` field** in `S3_BUCKETS` JSON
2. **Global `CLUSTER_NAME`** environment variable (fallback)
3. **Empty string `""`** — single-instance mode (no tagging)
### Example configurations
**Single instance (default, no changes required):**
```bash
# Nothing — data is ingested with cluster=""
```
**One instance per cluster:**
```bash
CLUSTER_NAME=prod-eu-west-1
```
**One instance, multiple clusters via per-bucket assignment:**
```json
S3_BUCKETS=[
  {"name":"prod-eu-sboms","cluster":"prod-eu"},
  {"name":"prod-us-sboms","cluster":"prod-us"},
  {"name":"staging-sboms","cluster":"staging"},
  {"name":"shared-sboms"}
]
CLUSTER_NAME=default
```
## Schema Migration
`db/migrations/012_add_cluster_column.up.sql` adds a non-destructive column to 6 core tables:
```sql
ALTER TABLE sboms          ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
ALTER TABLE sbom_packages  ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
ALTER TABLE vulnerabilities      ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
ALTER TABLE license_compliance   ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
ALTER TABLE ingestion_queue      ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
ALTER TABLE vex_statements       ADD COLUMN IF NOT EXISTS cluster LowCardinality(String) DEFAULT '';
```
**Note:** ORDER BY clauses are intentionally not modified — ClickHouse forbids altering ORDER BY on existing MergeTree tables without recreation. A future breaking migration can optimize ORDER BY for cluster-filtered queries.
## How Has This Been Tested?
- [x] `go test ./...` passes (8 new tests added)
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [ ] `ng build` (no UI changes in this PR)
- [ ] `helm lint` (no Helm changes in this PR)
- [x] Manual testing via Docker Compose
### New tests
**`backend/internal/config/config_test.go`** (3 new tests):
- `TestLoad_ClusterName_Default` — default empty value
- `TestLoad_ClusterName_Custom` — env var loading
- `TestLoad_S3BucketClusterOverride` — per-bucket cluster + global fallback
**`backend/pkg/models/models_test.go`** (6 new tests, new file):
- `TestSBOM_ClusterField` — field presence + JSON serialization
- `TestSBOM_ClusterOmitEmpty` — `omitempty` behavior
- `TestIngestionJob_ClusterPropagation` — job model
- `TestVulnerability_ClusterField` — vulnerability model
- `TestLicenseCompliance_ClusterField` — license compliance model
- `TestVEXStatement_ClusterField` — VEX model
## Documentation
- **README.md** — `CLUSTER_NAME` env var in `.env` table + per-bucket cluster example in S3 Ingestion section
- **AGENTS.md** — Updated to reference 12 migrations and the cluster column across all core tables; `internal/s3` package description mentions per-bucket cluster support
- **docs/architecture/** — New "Multi-Cluster Data Model" section with data flow diagram, config table, priority order
- **docs/deployment/** — New "Multi-Cluster Ingestion" section with Helm values examples for both single-instance and multi-cluster setups
- **docs/roadmap/ + ROADMAP.md** — Expanded #57 scope to "Project-aware data model" (orthogonal to cluster, in Phase 2), added "Why project model is separate from cluster model?" rationale section
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)
## Out of Scope (Follow-ups)
- API filtering by `?cluster=X` query param → **#132 (Cluster listing endpoint)**
- `GET /api/v1/clusters` endpoint → **#132**
- Frontend cluster picker → after #132 ships
- ORDER BY optimization to include cluster → breaking change, future major version
- Project-aware data model (orthogonal dimension) → expanded **#57**