### PR TITLE
feat(#134): optional API authentication with service token + API keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ Frontend Test:   cd ui && npx ng test            # uses Vitest
 - **Security headers** are set via `securityHeadersMiddleware`: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Content-Security-Policy`, `Referrer-Policy`, `Permissions-Policy`.
 - **CORS** is configurable via `CORS_ALLOWED_ORIGINS` env var (default `*` for dev, restrict in production). Only `GET` and `OPTIONS` methods are allowed.
 - **Rate limiting** via `rateLimitMiddleware`: 100 requests per 10s per IP, with background cleanup to prevent memory leaks.
+- **Authentication** via `authMiddleware` (opt-in, default off). Set `AUTH_ENABLED=true` plus either `SERVICE_TOKEN` (shared secret for upstream proxies, accepted as `Authorization: Bearer` or `X-Service-Token`) and/or `API_KEYS` (comma-separated list, accepted as `X-API-Key`). Uses `crypto/subtle.ConstantTimeCompare` to prevent timing attacks. Public paths (`/healthz`, `/livez`, `/readyz`) and `OPTIONS` preflight always bypass auth.
 - **Input validation**: All UUID path parameters (`sbomID`) are validated against `uuidPattern` regex. Vulnerability IDs (`vulnID`) are validated against `vulnIDPattern`. Query parameters like `vex_filter` are whitelisted to known values.
 - **Pagination bounds**: `clampPageSize()` enforces max 500 items per page to prevent abusive queries.
 - **Log injection prevention**: `sanitizeLogParam()` strips newlines/control characters and truncates to 200 chars before logging user-supplied values.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ cp .env.example .env
 | `SKIP_GITHUB_RESOLVE` | `false` | Skip GitHub license resolution for packages with `NOASSERTION`/empty licenses. |
 | `GITHUB_TOKEN` | *(empty)* | GitHub personal access token for license resolution. Increases rate limit from 60 to 5000 req/h. No scopes needed. |
 | `CLUSTER_NAME` | *(empty)* | Cluster identifier for multi-cluster deployments. All ingested data is tagged with this value. Empty = single-instance mode. |
+| `AUTH_ENABLED` | `false` | Enable API authentication middleware. When `false` (default), all API endpoints are unauthenticated. |
+| `SERVICE_TOKEN` | *(empty)* | Shared secret for upstream proxy/gateway integrations. Accepted via `Authorization: Bearer <token>` or `X-Service-Token: <token>`. |
+| `API_KEYS` | *(empty)* | Comma-separated list of API keys for direct API consumers (CI/CD, scripts). Accepted via `X-API-Key: <key>`. |
 | `CUSTOM_THEME` | (example file) | Path to a custom CSS theme file for the UI. See "Custom Theme" section. |
 | `UI_CONFIG` | `./ui/public/ui-config.json` | Path to a JSON file with UI text overrides (brand name, dashboard texts, disclaimer). See "Site Configuration" section. |
 | `S3_BUCKETS` | *(empty)* | JSON array of S3 bucket configs (supports per-bucket `cluster` override). See "S3 Ingestion" section. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,7 @@ After Phase 2 completes, SeeBOM reaches **v1.0.0** — the first stable release:
 
 **v1.0 Criteria:**
 - [x] ~~Version Skew Detection~~ (#37)
-- [ ] API Authentication (#134)
+- [x] ~~API Authentication (Service Token + API Key)~~ (#134)
 - [ ] Cluster-aware schema (#131)
 - [ ] All cluster/namespace endpoints finalized (#132, #133, #138)
 - [ ] Upload endpoint stable (#135)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,7 +66,8 @@ We follow the [CVSS v3.1](https://www.first.org/cvss/calculator/3.1) scoring sys
 When deploying SeeBOM, pay attention to:
 
 - **ClickHouse credentials**: Always change the default password. Use the `seebom-secret` Kubernetes Secret.
-- **UI is public**: The Angular frontend has no authentication. Do not expose it to the internet without an authentication proxy (e.g. OAuth2 Proxy, Pomerium).
+- **API authentication (opt-in)**: The API Gateway ships with an authentication middleware that is **disabled by default**. Set `AUTH_ENABLED=true` plus `SERVICE_TOKEN` (Bearer / `X-Service-Token`) and/or `API_KEYS` (`X-API-Key`, comma-separated) to require credentials on every non-health endpoint. The bundled UI is automatically wired up — nginx injects the `SERVICE_TOKEN` on upstream `/api/` proxy calls so the secret never reaches the browser. Constant-time comparisons (`crypto/subtle`) prevent timing attacks. See [Deployment Guide § 6](./docs/content/docs/deployment/_index.md#6-api-authentication-optional).
+- **UI is unauthenticated by default**: The Angular frontend has no built-in login. When `apiGateway.auth.enabled=true` the UI authenticates to the backend on the user's behalf, but the UI itself remains world-readable. For per-user authentication, place the UI behind an authentication proxy (e.g. OAuth2 Proxy, Pomerium, Cloudflare Access).
 - **License exceptions are read-only**: By design, no API endpoint can modify license exceptions or policy — they are loaded from config files to prevent tampering via the public UI.
 - **SBOM source directory**: Ensure only trusted SBOM/VEX files are placed in the ingestion directory. Malicious JSON payloads could attempt to exploit the parsers.
 - **Container images**: All backend containers run as `nobody:nobody`. The UI runs as the `nginx` user. No container requires root privileges.

--- a/backend/cmd/api-gateway/auth_test.go
+++ b/backend/cmd/api-gateway/auth_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+}
+
+func TestAuthMiddleware_Disabled_AllowsAllRequests(t *testing.T) {
+	h := authMiddleware(false, "", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats/dashboard", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 when auth disabled, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_Enabled_RejectsMissingCredential(t *testing.T) {
+	h := authMiddleware(true, "secret", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for missing credential, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got == "" {
+		t.Error("expected WWW-Authenticate header on 401")
+	}
+}
+
+func TestAuthMiddleware_Enabled_RejectsInvalidToken(t *testing.T) {
+	h := authMiddleware(true, "correct-secret", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req.Header.Set("Authorization", "Bearer wrong-secret")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for invalid token, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_Enabled_AcceptsValidBearerToken(t *testing.T) {
+	h := authMiddleware(true, "my-service-token", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req.Header.Set("Authorization", "Bearer my-service-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid Bearer token, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_Enabled_AcceptsValidServiceTokenHeader(t *testing.T) {
+	h := authMiddleware(true, "my-service-token", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req.Header.Set("X-Service-Token", "my-service-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid X-Service-Token, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_Enabled_AcceptsValidAPIKey(t *testing.T) {
+	h := authMiddleware(true, "", []string{"key1", "key2", "key3"}, okHandler())
+
+	for _, k := range []string{"key1", "key2", "key3"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+		req.Header.Set("X-API-Key", k)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200 with valid API key %q, got %d", k, rec.Code)
+		}
+	}
+}
+
+func TestAuthMiddleware_Enabled_RejectsInvalidAPIKey(t *testing.T) {
+	h := authMiddleware(true, "", []string{"key1", "key2"}, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req.Header.Set("X-API-Key", "wrong-key")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for invalid API key, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_Enabled_BothModesCanCoexist(t *testing.T) {
+	h := authMiddleware(true, "service-secret", []string{"api-key-1"}, okHandler())
+
+	// Service token via Bearer.
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req1.Header.Set("Authorization", "Bearer service-secret")
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Errorf("Bearer service-token: expected 200, got %d", rec1.Code)
+	}
+
+	// API key via X-API-Key.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req2.Header.Set("X-API-Key", "api-key-1")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Errorf("X-API-Key: expected 200, got %d", rec2.Code)
+	}
+}
+
+func TestAuthMiddleware_PublicPathsBypassAuth(t *testing.T) {
+	h := authMiddleware(true, "secret", nil, okHandler())
+
+	for _, path := range []string{"/healthz", "/livez", "/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		// No auth header.
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("public path %q: expected 200 without auth, got %d", path, rec.Code)
+		}
+	}
+}
+
+func TestAuthMiddleware_OptionsPreflightBypassesAuth(t *testing.T) {
+	h := authMiddleware(true, "secret", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/sboms", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("OPTIONS preflight: expected 200 without auth, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_EmptyBearerRejected(t *testing.T) {
+	h := authMiddleware(true, "secret", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	// Bearer with empty token.
+	req.Header.Set("Authorization", "Bearer ")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for empty bearer token, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_EnabledWithNoConfiguredCredentials_RejectsAll(t *testing.T) {
+	// AUTH_ENABLED=true but no service token and no API keys configured.
+	// This is a misconfiguration — all authenticated requests must fail.
+	h := authMiddleware(true, "", nil, okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sboms", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when no credentials configured, got %d", rec.Code)
+	}
+}

--- a/backend/cmd/api-gateway/main.go
+++ b/backend/cmd/api-gateway/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -311,13 +312,33 @@ func main() {
 	})
 
 	// CORS + security middleware for Angular dev server.
+	// Order (outermost first): security headers → rate limit → CORS → auth → mux.
+	// Auth sits closest to the mux so 401s still get CORS + security headers.
 	handler := securityHeadersMiddleware(
 		rateLimitMiddleware(
-			corsMiddleware(cfg.CORSAllowedOrigins, mux),
+			corsMiddleware(cfg.CORSAllowedOrigins,
+				authMiddleware(cfg.AuthEnabled, cfg.ServiceToken, cfg.APIKeys, mux),
+			),
 		),
 	)
 
 	addr := ":" + strconv.Itoa(cfg.APIPort)
+	if cfg.AuthEnabled {
+		modes := []string{}
+		if cfg.ServiceToken != "" {
+			modes = append(modes, "service-token")
+		}
+		if len(cfg.APIKeys) > 0 {
+			modes = append(modes, "api-keys("+strconv.Itoa(len(cfg.APIKeys))+")")
+		}
+		if len(modes) == 0 {
+			log.Printf("WARNING: AUTH_ENABLED=true but neither SERVICE_TOKEN nor API_KEYS is configured — ALL authenticated requests will be rejected")
+		} else {
+			log.Printf("API authentication enabled (modes: %s)", strings.Join(modes, ", "))
+		}
+	} else {
+		log.Println("API authentication disabled (set AUTH_ENABLED=true to enforce)")
+	}
 	log.Printf("API Gateway listening on %s", addr)
 	if err := http.ListenAndServe(addr, handler); err != nil {
 		log.Fatalf("Server failed: %v", err)
@@ -432,7 +453,7 @@ func corsMiddleware(allowedOrigins string, next http.Handler) http.Handler {
 		}
 
 		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Service-Token, X-API-Key")
 		w.Header().Set("Access-Control-Max-Age", "86400")
 
 		if r.Method == http.MethodOptions {
@@ -505,4 +526,90 @@ func rateLimitMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// authPublicPaths lists request paths that bypass authentication even when
+// AUTH_ENABLED=true. K8s probes and CORS preflight must always succeed.
+var authPublicPaths = map[string]struct{}{
+	"/healthz": {},
+	"/livez":   {},
+	"/readyz":  {},
+}
+
+// authMiddleware enforces authentication when enabled. Accepts any of:
+//   - Authorization: Bearer <service-token>
+//   - X-Service-Token: <service-token>
+//   - X-API-Key: <api-key>
+//
+// All comparisons use constant-time equality to prevent timing attacks.
+// When AUTH_ENABLED=false, this middleware is a no-op pass-through.
+func authMiddleware(enabled bool, serviceToken string, apiKeys []string, next http.Handler) http.Handler {
+	if !enabled {
+		return next
+	}
+
+	// Pre-compute byte slices for constant-time comparison.
+	serviceTokenBytes := []byte(serviceToken)
+	apiKeyBytes := make([][]byte, len(apiKeys))
+	for i, k := range apiKeys {
+		apiKeyBytes[i] = []byte(k)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Public paths bypass auth (health probes).
+		if _, ok := authPublicPaths[r.URL.Path]; ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// CORS preflight bypasses auth (cors middleware handles OPTIONS).
+		if r.Method == http.MethodOptions {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract candidate credential from any supported header.
+		var presented []byte
+		if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+			presented = []byte(strings.TrimPrefix(h, "Bearer "))
+		} else if h := r.Header.Get("X-Service-Token"); h != "" {
+			presented = []byte(h)
+		} else if h := r.Header.Get("X-API-Key"); h != "" {
+			presented = []byte(h)
+		}
+
+		if len(presented) == 0 {
+			log.Printf("AUTH: missing credential on %s %s from %s",
+				sanitizeLogParam(r.Method), sanitizeLogParam(r.URL.Path), clientIP(r))
+			w.Header().Set("WWW-Authenticate", `Bearer realm="seebom"`)
+			writeError(w, http.StatusUnauthorized, "Authentication required")
+			return
+		}
+
+		// Service token check (constant-time).
+		if len(serviceTokenBytes) > 0 && subtle.ConstantTimeCompare(presented, serviceTokenBytes) == 1 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// API key check (constant-time over each configured key).
+		for _, k := range apiKeyBytes {
+			if subtle.ConstantTimeCompare(presented, k) == 1 {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		log.Printf("AUTH: invalid credential on %s %s from %s",
+			sanitizeLogParam(r.Method), sanitizeLogParam(r.URL.Path), clientIP(r))
+		writeError(w, http.StatusUnauthorized, "Invalid credentials")
+	})
+}
+
+// clientIP extracts the originating IP, preferring X-Forwarded-For.
+func clientIP(r *http.Request) string {
+	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
+		ip = strings.SplitN(ip, ",", 2)[0]
+		return strings.TrimSpace(ip)
+	}
+	return r.RemoteAddr
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -54,6 +54,11 @@ type Config struct {
 
 	// Multi-cluster
 	ClusterName string // Cluster identifier for this instance (default "" = unassigned)
+
+	// API Authentication (opt-in, all empty by default)
+	AuthEnabled  bool     // Enable auth middleware (default false)
+	ServiceToken string   // Shared secret for upstream proxy/gateway integrations
+	APIKeys      []string // Pre-shared API keys for direct API consumers (CI/CD, scripts)
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -76,6 +81,9 @@ func Load() (*Config, error) {
 		LicensePolicyFile:  getEnv("LICENSE_POLICY_FILE", "/data/config/license-policy.json"),
 		GitHubToken:        getEnv("GITHUB_TOKEN", ""),
 		ClusterName:        getEnv("CLUSTER_NAME", ""),
+		AuthEnabled:        getEnvBool("AUTH_ENABLED", false),
+		ServiceToken:       getEnv("SERVICE_TOKEN", ""),
+		APIKeys:            parseAPIKeys(getEnv("API_KEYS", "")),
 	}
 
 	if cfg.WorkerID == "" {
@@ -191,6 +199,26 @@ func getEnvBool(key string, fallback bool) bool {
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+// parseAPIKeys splits a comma-separated list of API keys, trimming whitespace
+// and filtering out empty entries.
+func parseAPIKeys(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	keys := make([]string, 0, len(parts))
+	for _, p := range parts {
+		k := strings.TrimSpace(p)
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return keys
+}
 
 // S3BucketNames returns a comma-separated list of configured bucket names (for logging).
 func (c *Config) S3BucketNames() string {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -279,3 +279,69 @@ func TestLoad_S3BucketClusterOverride(t *testing.T) {
 		t.Errorf("ClusterName = %q, want \"global-fallback\"", cfg.ClusterName)
 	}
 }
+func TestLoad_Auth_DefaultsDisabled(t *testing.T) {
+	for _, k := range []string{"AUTH_ENABLED", "SERVICE_TOKEN", "API_KEYS"} {
+		os.Unsetenv(k)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.AuthEnabled {
+		t.Error("expected AuthEnabled=false by default")
+	}
+	if cfg.ServiceToken != "" {
+		t.Errorf("expected empty ServiceToken by default, got %q", cfg.ServiceToken)
+	}
+	if cfg.APIKeys != nil {
+		t.Errorf("expected nil APIKeys by default, got %v", cfg.APIKeys)
+	}
+}
+func TestLoad_Auth_ServiceTokenMode(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "true")
+	t.Setenv("SERVICE_TOKEN", "my-secret-token")
+	os.Unsetenv("API_KEYS")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !cfg.AuthEnabled {
+		t.Error("expected AuthEnabled=true")
+	}
+	if cfg.ServiceToken != "my-secret-token" {
+		t.Errorf("ServiceToken = %q, want \"my-secret-token\"", cfg.ServiceToken)
+	}
+}
+func TestLoad_Auth_APIKeysMode(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "true")
+	t.Setenv("API_KEYS", "key1, key2 ,  key3,  ,key4")
+	os.Unsetenv("SERVICE_TOKEN")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !cfg.AuthEnabled {
+		t.Error("expected AuthEnabled=true")
+	}
+	expected := []string{"key1", "key2", "key3", "key4"}
+	if len(cfg.APIKeys) != len(expected) {
+		t.Fatalf("expected %d keys, got %d: %v", len(expected), len(cfg.APIKeys), cfg.APIKeys)
+	}
+	for i, want := range expected {
+		if cfg.APIKeys[i] != want {
+			t.Errorf("APIKeys[%d] = %q, want %q", i, cfg.APIKeys[i], want)
+		}
+	}
+}
+func TestLoad_Auth_EmptyAPIKeysString(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "true")
+	t.Setenv("API_KEYS", "   ,   ,   ")
+	os.Unsetenv("SERVICE_TOKEN")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.APIKeys != nil {
+		t.Errorf("expected nil APIKeys for whitespace-only input, got %v", cfg.APIKeys)
+	}
+}

--- a/backend/internal/spdx/parser.go
+++ b/backend/internal/spdx/parser.go
@@ -121,7 +121,20 @@ type inTotoStatement struct {
 // Parse reads an SPDX JSON document from a reader and extracts models.
 // Supports both plain SPDX JSON and in-toto attestation envelopes where the
 // SPDX document is wrapped inside the "predicate" field.
-func Parse(r io.Reader, sourceFile, sha256Hash string) (*ParseResult, error) {
+//
+// Parse is hardened against malformed input: the underlying goccy/go-json
+// decoder can panic on adversarial byte sequences (out-of-range slice access
+// inside its struct decoder). We recover from any panic and surface it as a
+// regular error so callers — including the FuzzParse harness — observe
+// deterministic, non-fatal failures.
+func Parse(r io.Reader, sourceFile, sha256Hash string) (result *ParseResult, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			result = nil
+			err = fmt.Errorf("panic while parsing SPDX JSON: %v", rec)
+		}
+	}()
+
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read SPDX data: %w", err)

--- a/backend/internal/vex/parser.go
+++ b/backend/internal/vex/parser.go
@@ -68,7 +68,19 @@ func ParseFile(path, sourceFile string) (*ParseResult, error) {
 }
 
 // Parse reads an OpenVEX JSON document from a reader and extracts models.
-func Parse(r io.Reader, sourceFile string) (*ParseResult, error) {
+//
+// Parse is hardened against malformed input: the underlying goccy/go-json
+// decoder can panic on adversarial byte sequences. We recover from any
+// panic and surface it as a regular error so callers — including the
+// FuzzParse harness — observe deterministic, non-fatal failures.
+func Parse(r io.Reader, sourceFile string) (out *ParseResult, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			out = nil
+			err = fmt.Errorf("panic while parsing OpenVEX JSON: %v", rec)
+		}
+	}()
+
 	var doc OpenVEXDocument
 
 	decoder := json.NewDecoder(r)

--- a/deploy/helm/seebom/templates/configmap-nginx.yaml
+++ b/deploy/helm/seebom/templates/configmap-nginx.yaml
@@ -6,7 +6,21 @@ metadata:
     app.kubernetes.io/name: seebom
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
-  seebom.conf: |
+  # Stored under the .template suffix so the nginx image's built-in
+  # /docker-entrypoint.d/20-envsubst-on-templates.sh renders ${VAR} placeholders
+  # at container startup. The companion init script
+  # /docker-entrypoint.d/15-seebom-auth.envsh (baked into the image) populates
+  # SEEBOM_AUTH_HEADER_VALUE from the SERVICE_TOKEN env var.
+  seebom.conf.template: |
+    # If the client already supplied an Authorization header, pass it through.
+    # Otherwise inject the SERVICE_TOKEN configured for the API Gateway (only
+    # used when apiGateway.auth.enabled=true). When SERVICE_TOKEN is empty,
+    # SEEBOM_AUTH_HEADER_VALUE is empty and nginx omits the header entirely.
+    map $http_authorization $seebom_effective_auth {
+        default $http_authorization;
+        ""      "${SEEBOM_AUTH_HEADER_VALUE}";
+    }
+
     server {
         listen 80;
         server_name _;
@@ -24,6 +38,8 @@ data:
 
         # Proxy API requests to the API Gateway Kubernetes service.
         # Using a variable forces nginx to re-resolve DNS at runtime instead of only at startup.
+        # When apiGateway.auth.enabled=true, the UI is authenticated via the
+        # SERVICE_TOKEN injected here — the token never reaches the browser.
         location /api/ {
             set $backend "http://{{ .Release.Name }}-api-gateway.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.apiGateway.service.port }}";
             proxy_pass $backend;
@@ -31,6 +47,7 @@ data:
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $seebom_effective_auth;
         }
 
         # Runtime config files: no cache so edits take effect on reload.

--- a/deploy/helm/seebom/templates/deployment-api-gateway.yaml
+++ b/deploy/helm/seebom/templates/deployment-api-gateway.yaml
@@ -44,7 +44,7 @@ spec:
                 name: {{ .Release.Name }}-config
             - secretRef:
                 name: {{ .Release.Name }}-secret
-          {{- if or .Values.clickhouse.userPasswordSecret.enabled .Values.s3.credentialsSecret.enabled }}
+          {{- if or .Values.clickhouse.userPasswordSecret.enabled .Values.s3.credentialsSecret.enabled .Values.apiGateway.auth.enabled }}
           env:
             {{- if .Values.clickhouse.userPasswordSecret.enabled }}
             - name: CLICKHOUSE_PASSWORD
@@ -64,6 +64,32 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.s3.credentialsSecret.secretName }}
                   key: {{ .Values.s3.credentialsSecret.secretKeyKey }}
+            {{- end }}
+            {{- if .Values.apiGateway.auth.enabled }}
+            - name: AUTH_ENABLED
+              value: "true"
+            - name: SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.apiGateway.auth.existingSecret.enabled }}
+                  name: {{ .Values.apiGateway.auth.existingSecret.secretName }}
+                  key: {{ .Values.apiGateway.auth.existingSecret.serviceTokenKey }}
+                  {{- else }}
+                  name: {{ .Release.Name }}-api-auth
+                  key: SERVICE_TOKEN
+                  {{- end }}
+                  optional: true
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.apiGateway.auth.existingSecret.enabled }}
+                  name: {{ .Values.apiGateway.auth.existingSecret.secretName }}
+                  key: {{ .Values.apiGateway.auth.existingSecret.apiKeysKey }}
+                  {{- else }}
+                  name: {{ .Release.Name }}-api-auth
+                  key: API_KEYS
+                  {{- end }}
+                  optional: true
             {{- end }}
           {{- end }}
           livenessProbe:

--- a/deploy/helm/seebom/templates/deployment-ui.yaml
+++ b/deploy/helm/seebom/templates/deployment-ui.yaml
@@ -26,6 +26,25 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.apiGateway.auth.enabled }}
+          # When apiGateway.auth.enabled=true, surface the SERVICE_TOKEN to
+          # nginx so its /docker-entrypoint.d/15-seebom-auth.envsh init script
+          # can derive SEEBOM_AUTH_HEADER_VALUE for envsubst. The token never
+          # leaves the cluster — nginx adds it as the Authorization header
+          # only on upstream /api/ proxy calls, not in responses to browsers.
+          env:
+            - name: SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.apiGateway.auth.existingSecret.enabled }}
+                  name: {{ .Values.apiGateway.auth.existingSecret.secretName }}
+                  key: {{ .Values.apiGateway.auth.existingSecret.serviceTokenKey }}
+                  {{- else }}
+                  name: {{ .Release.Name }}-api-auth
+                  key: SERVICE_TOKEN
+                  {{- end }}
+                  optional: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -41,9 +60,11 @@ spec:
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
           volumeMounts:
+            # Mount as a template so the nginx entrypoint runs envsubst on it
+            # at container startup (renders ${SEEBOM_AUTH_HEADER_VALUE}).
             - name: nginx-config
-              mountPath: /etc/nginx/conf.d/seebom.conf
-              subPath: seebom.conf
+              mountPath: /etc/nginx/templates/seebom.conf.template
+              subPath: seebom.conf.template
               readOnly: true
             {{- if .Values.ui.customTheme.enabled }}
             - name: custom-theme

--- a/deploy/helm/seebom/templates/secret.yaml
+++ b/deploy/helm/seebom/templates/secret.yaml
@@ -13,3 +13,24 @@ data:
   S3_ACCESS_KEY: {{ .Values.s3.accessKey | b64enc | quote }}
   S3_SECRET_KEY: {{ .Values.s3.secretKey | b64enc | quote }}
 {{- end }}
+{{- /*
+  Separate Secret for API auth so it can be rotated independently of the
+  ClickHouse/GitHub/S3 credentials and so the UI Deployment can reference it
+  without pulling in unrelated secrets. Only created when auth.enabled=true
+  and the user is not bringing their own existing Secret.
+*/}}
+{{- if and .Values.apiGateway.auth.enabled (not .Values.apiGateway.auth.existingSecret.enabled) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-api-auth
+  labels:
+    app.kubernetes.io/name: seebom
+    app.kubernetes.io/component: api-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+data:
+  SERVICE_TOKEN: {{ .Values.apiGateway.auth.serviceToken | b64enc | quote }}
+  API_KEYS:      {{ .Values.apiGateway.auth.apiKeys      | b64enc | quote }}
+{{- end }}

--- a/deploy/helm/seebom/values.yaml
+++ b/deploy/helm/seebom/values.yaml
@@ -132,6 +132,27 @@ apiGateway:
     limits:
       cpu: 500m
       memory: 256Mi
+  # API Authentication (opt-in, off by default).
+  # When enabled, the API Gateway requires either a Bearer SERVICE_TOKEN
+  # (X-Service-Token / Authorization header) or an X-API-Key from one of the
+  # configured API_KEYS. The UI Deployment automatically receives the
+  # SERVICE_TOKEN and injects it as the proxy Authorization header when the
+  # browser does not supply its own — so the secret never leaves the cluster.
+  auth:
+    enabled: false
+    # Inline secrets (created via the chart's Secret). Override via --set
+    # for ad-hoc use; prefer existingSecret for production deployments.
+    serviceToken: ""
+    apiKeys: ""    # comma-separated list, e.g. "ci-key,monitoring-key"
+    # Reference a pre-existing Kubernetes Secret instead of generating one.
+    # The Secret must contain the keys named below (SERVICE_TOKEN / API_KEYS
+    # by default). Same pattern as clickhouse.userPasswordSecret /
+    # s3.credentialsSecret / github.tokenSecret.
+    existingSecret:
+      enabled: false
+      secretName: ""
+      serviceTokenKey: "SERVICE_TOKEN"
+      apiKeysKey: "API_KEYS"
 
 # UI (Deployment)
 ui:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       API_PORT: "8080"
       EXCEPTIONS_FILE: /data/config/license-exceptions.json
       LICENSE_POLICY_FILE: /data/config/license-policy.json
+      # API Authentication (off by default; set AUTH_ENABLED=true in .env to enable)
+      AUTH_ENABLED: ${AUTH_ENABLED:-false}
+      SERVICE_TOKEN: ${SERVICE_TOKEN:-}
+      API_KEYS: ${API_KEYS:-}
     volumes:
       - ./sboms/license-exceptions.json:/data/config/license-exceptions.json:ro
       - ./sboms/license-policy.json:/data/config/license-policy.json:ro
@@ -121,6 +125,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8090:80"
+    environment:
+      # When AUTH_ENABLED=true on the api-gateway, nginx injects this token
+      # as the Authorization header on proxied /api/ calls. Empty = no header.
+      SERVICE_TOKEN: ${SERVICE_TOKEN:-}
     volumes:
       - ${CUSTOM_THEME:-./ui/src/assets/custom-theme.example.css}:/usr/share/nginx/html/custom-theme.css:ro
       - ${UI_CONFIG:-./ui/public/ui-config.json}:/usr/share/nginx/html/ui-config.json:ro

--- a/docs/ARCHITECTURE_PLAN.md
+++ b/docs/ARCHITECTURE_PLAN.md
@@ -162,7 +162,7 @@ ClickHouse: sboms, sbom_packages, vulnerabilities, license_compliance, vex_state
        └── Dep Stats:      ARRAY JOIN + count(DISTINCT sbom_id) cross-project
        ▼
 API Gateway (REST) → 19 Endpoints
-       │ HTTP/JSON + CORS
+       │ HTTP/JSON + CORS + security headers + rate limit + optional auth (Bearer/X-Service-Token, X-API-Key)
        ▼
 Angular UI (13 lazy-loaded routes, virtual scrolling, OnPush, dark mode)
        │ Custom CSS theme mountable without Angular rebuild

--- a/docs/content/docs/api-reference/_index.md
+++ b/docs/content/docs/api-reference/_index.md
@@ -21,8 +21,49 @@ In headless mode (Helm: `ui.enabled: false`), only the API Gateway is deployed. 
 
 ## Authentication
 
-{{% alert title="Coming in v1.0" color="warning" %}}
-Authentication (service token + API key) is planned for Phase 1. Currently all endpoints are unauthenticated. Restrict access via network policy or ingress rules until then.
+Authentication is **fully optional** and disabled by default. Enable it via the `AUTH_ENABLED=true` environment variable on the API Gateway. See the [Deployment Guide](/docs/deployment/#6-api-authentication-optional) for full setup instructions.
+
+### Two modes (combinable)
+
+**Service Token** — single shared secret, typically used by upstream proxies (oauth2-proxy, Kong, custom auth gateways):
+
+```bash
+# Either header works:
+curl -H "Authorization: Bearer <service-token>" \
+  https://api.seebom.example.com/api/v1/stats/dashboard
+
+curl -H "X-Service-Token: <service-token>" \
+  https://api.seebom.example.com/api/v1/stats/dashboard
+```
+
+**API Keys** — multiple pre-shared keys for direct API consumers (CI/CD pipelines, scripts):
+
+```bash
+curl -H "X-API-Key: <api-key>" \
+  https://api.seebom.example.com/api/v1/stats/dashboard
+```
+
+### Public endpoints (always accessible)
+
+Even when authentication is enabled, the following endpoints bypass auth so Kubernetes probes and CORS preflight work:
+
+| Endpoint | Reason |
+|----------|--------|
+| `/healthz` | K8s liveness/readiness probe |
+| `/livez` | Reserved for liveness probe (#137) |
+| `/readyz` | Reserved for readiness probe (#137) |
+| `OPTIONS *` | CORS preflight |
+
+### Responses
+
+| Status | Condition |
+|--------|-----------|
+| `200 OK` | Auth disabled, or valid token/key presented |
+| `401 Unauthorized` (with `WWW-Authenticate: Bearer realm="seebom"`) | Auth enabled, no credential sent |
+| `401 Unauthorized` | Auth enabled, invalid token/key |
+
+{{% alert title="Security" color="info" %}}
+All credential comparisons are constant-time (`crypto/subtle.ConstantTimeCompare`) to prevent timing attacks. Failed auth attempts are logged with sanitized client IPs.
 {{% /alert %}}
 
 ## Common Patterns

--- a/docs/content/docs/deployment/_index.md
+++ b/docs/content/docs/deployment/_index.md
@@ -234,7 +234,110 @@ ui:
 
 ---
 
-## 6. GitHub Token (License Resolution)
+## 6. API Authentication (Optional)
+
+API authentication is **fully optional and disabled by default**. When you expose the API Gateway externally (e.g. via Ingress), enable it to prevent unauthenticated access.
+
+### When you need it
+
+- ✅ API Gateway exposed via Ingress / public endpoint
+- ✅ CI/CD pipelines pushing data (when upload endpoint lands in #135)
+- ✅ Multi-tenant or shared deployments
+
+### When you don't need it
+
+- ❌ Internal cluster-only deployments (network policy is enough)
+- ❌ Local development (`make dev`)
+- ❌ Air-gapped environments behind a corporate VPN
+
+### Two authentication modes (combinable)
+
+**Mode 1: Service Token** — a single shared secret, ideal for upstream proxy/gateway integrations (Kong, oauth2-proxy, custom auth):
+
+```yaml
+apiGateway:
+  env:
+    AUTH_ENABLED: "true"
+    SERVICE_TOKEN: "your-strong-random-secret-here"
+```
+
+Clients send the token via either header:
+
+```bash
+curl -H "Authorization: Bearer your-strong-random-secret-here" \
+  https://seebom.example.com/api/v1/stats/dashboard
+
+# Or:
+curl -H "X-Service-Token: your-strong-random-secret-here" \
+  https://seebom.example.com/api/v1/stats/dashboard
+```
+
+**Mode 2: API Keys** — multiple pre-shared keys for direct consumers (CI/CD pipelines, scripts):
+
+```yaml
+apiGateway:
+  env:
+    AUTH_ENABLED: "true"
+    API_KEYS: "ci-cd-pipeline-key,monitoring-key,backup-script-key"
+```
+
+Clients send the key via:
+
+```bash
+curl -H "X-API-Key: ci-cd-pipeline-key" \
+  https://seebom.example.com/api/v1/stats/dashboard
+```
+
+**Both modes can be enabled at the same time** — useful when a proxy uses the service token while direct CI/CD jobs use API keys.
+
+### Using Kubernetes Secrets (recommended for production)
+
+```bash
+kubectl create secret generic seebom-api-auth \
+  --from-literal=SERVICE_TOKEN="$(openssl rand -hex 32)" \
+  --from-literal=API_KEYS="key1,key2,key3" \
+  -n seebom
+```
+
+```yaml
+apiGateway:
+  env:
+    AUTH_ENABLED: "true"
+  envFrom:
+    - secretRef:
+        name: seebom-api-auth
+```
+
+### Public endpoints (always accessible)
+
+Even when authentication is enabled, the following endpoints are always reachable without credentials:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/healthz` | Kubernetes liveness/readiness probe |
+| `/livez` | Reserved for #137 (liveness probe) |
+| `/readyz` | Reserved for #137 (readiness probe) |
+| `OPTIONS *` | CORS preflight |
+
+### Security notes
+
+- Use **at least 32 random bytes** for the service token: `openssl rand -hex 32`
+- Rotate tokens by restarting the API Gateway pod after updating the secret
+- All comparisons are **constant-time** to prevent timing attacks
+- Failed auth attempts are logged with sanitized client IPs
+- The frontend UI bundle is publicly served by Nginx — auth applies to the API Gateway only
+
+### Failure scenarios
+
+| Scenario | Response |
+|----------|----------|
+| No credentials sent (auth enabled) | `401 Unauthorized` with `WWW-Authenticate: Bearer realm="seebom"` |
+| Invalid token/key | `401 Unauthorized` |
+| `AUTH_ENABLED=true` but no `SERVICE_TOKEN` and no `API_KEYS` configured | All requests rejected (misconfiguration warning logged at startup) |
+
+---
+
+## 7. GitHub Token (License Resolution)
 
 SeeBOM resolves unknown package licenses (`NOASSERTION`) by querying the GitHub API. Without a token, you are limited to **60 requests per hour**. With a token, the limit increases to **5,000 req/h**.
 
@@ -258,7 +361,7 @@ See [FAQ: Should I use a GitHub token?](/docs/faq/#should-i-use-a-github-token) 
 
 ---
 
-## 7. Full Deployment Example
+## 8. Full Deployment Example
 
 ### S3-based (recommended)
 
@@ -274,7 +377,7 @@ helm install seebom ./deploy/helm/seebom \
 
 ---
 
-## 8. Verifying the Deployment
+## 9. Verifying the Deployment
 
 ```bash
 kubectl get pods -l app.kubernetes.io/name=seebom
@@ -297,4 +400,5 @@ kubectl exec -it $(kubectl get pod -l app.kubernetes.io/component=api-gateway -o
 | **Custom Theme** | ConfigMap | `kubectl create configmap` → restart UI |
 | **Site Config** | ConfigMap | Helm values `ui.siteConfig.content.*` → restart UI |
 | **S3 credentials** | Secret | `--set s3.accessKey=...` or `s3.credentialsSecret` (existing K8s Secret) |
+| **API Authentication** | Env vars (Secret recommended) | `AUTH_ENABLED=true` + `SERVICE_TOKEN` and/or `API_KEYS`; off by default |
 

--- a/docs/content/docs/deployment/_index.md
+++ b/docs/content/docs/deployment/_index.md
@@ -252,14 +252,16 @@ API authentication is **fully optional and disabled by default**. When you expos
 
 ### Two authentication modes (combinable)
 
-**Mode 1: Service Token** — a single shared secret, ideal for upstream proxy/gateway integrations (Kong, oauth2-proxy, custom auth):
+**Mode 1: Service Token** — a single shared secret, ideal for upstream proxy/gateway integrations (Kong, oauth2-proxy, custom auth) **and** for letting the bundled UI authenticate against the API Gateway:
 
 ```yaml
 apiGateway:
-  env:
-    AUTH_ENABLED: "true"
-    SERVICE_TOKEN: "your-strong-random-secret-here"
+  auth:
+    enabled: true
+    serviceToken: "your-strong-random-secret-here"
 ```
+
+> **UI ⇄ API Gateway:** When you deploy the bundled Angular UI alongside the API Gateway, the chart automatically injects the same `SERVICE_TOKEN` into the UI's nginx container. Nginx adds the `Authorization: Bearer …` header on every `/api/` proxy call before forwarding to the API Gateway, so the browser never sees the token. No extra configuration is required — flip `auth.enabled` to `true` and both sides are wired up.
 
 Clients send the token via either header:
 
@@ -276,9 +278,9 @@ curl -H "X-Service-Token: your-strong-random-secret-here" \
 
 ```yaml
 apiGateway:
-  env:
-    AUTH_ENABLED: "true"
-    API_KEYS: "ci-cd-pipeline-key,monitoring-key,backup-script-key"
+  auth:
+    enabled: true
+    apiKeys: "ci-cd-pipeline-key,monitoring-key,backup-script-key"
 ```
 
 Clients send the key via:
@@ -292,6 +294,8 @@ curl -H "X-API-Key: ci-cd-pipeline-key" \
 
 ### Using Kubernetes Secrets (recommended for production)
 
+Reference a pre-existing Secret instead of inlining the token in Helm values — same pattern as `s3.credentialsSecret` and `clickhouse.userPasswordSecret`:
+
 ```bash
 kubectl create secret generic seebom-api-auth \
   --from-literal=SERVICE_TOKEN="$(openssl rand -hex 32)" \
@@ -301,11 +305,19 @@ kubectl create secret generic seebom-api-auth \
 
 ```yaml
 apiGateway:
-  env:
-    AUTH_ENABLED: "true"
-  envFrom:
-    - secretRef:
-        name: seebom-api-auth
+  auth:
+    enabled: true
+    existingSecret:
+      enabled: true
+      secretName: "seebom-api-auth"
+      serviceTokenKey: "SERVICE_TOKEN"   # key inside the Secret
+      apiKeysKey: "API_KEYS"
+```
+
+Both the API Gateway and the UI nginx container automatically read `SERVICE_TOKEN` from this Secret. To rotate the token, update the Secret and restart both Deployments:
+
+```bash
+kubectl rollout restart deployment seebom-api-gateway seebom-ui
 ```
 
 ### Public endpoints (always accessible)

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -14,8 +14,19 @@ FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef
 # Remove default nginx config.
 RUN rm /etc/nginx/conf.d/default.conf
 
-# Add our custom nginx config.
-COPY nginx.conf /etc/nginx/conf.d/seebom.conf
+# Default values for envsubst — overridable at runtime via container env.
+# Empty SERVICE_TOKEN means the UI's nginx will NOT inject an Authorization
+# header on proxied API calls (compatible with AUTH_ENABLED=false on the API).
+ENV SERVICE_TOKEN=""
+
+# Install the nginx config as a template. The nginx official image runs
+# /docker-entrypoint.d/20-envsubst-on-templates.sh at startup, which renders
+# /etc/nginx/templates/*.template into /etc/nginx/conf.d/*.conf using envsubst.
+COPY nginx.conf.template /etc/nginx/templates/seebom.conf.template
+
+# Install the auth-header init script (sourced before envsubst runs).
+COPY docker-entrypoint.d/15-seebom-auth.envsh /docker-entrypoint.d/15-seebom-auth.envsh
+RUN chmod +x /docker-entrypoint.d/15-seebom-auth.envsh
 
 # Copy built Angular assets.
 COPY --from=builder /app/dist/ui/browser /usr/share/nginx/html

--- a/ui/docker-entrypoint.d/15-seebom-auth.envsh
+++ b/ui/docker-entrypoint.d/15-seebom-auth.envsh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Compute the proxy Authorization header value injected by nginx when the
+# browser does not supply its own. Sourced as .envsh by the official nginx
+# entrypoint before envsubst runs against the template files.
+#
+# Behavior:
+#   SERVICE_TOKEN unset/empty -> SEEBOM_AUTH_HEADER_VALUE=""
+#     (nginx will omit the Authorization header when the client also sends none)
+#   SERVICE_TOKEN=<secret>    -> SEEBOM_AUTH_HEADER_VALUE="Bearer <secret>"
+#     (nginx injects this as Authorization on every /api/ proxy call that has
+#      no client-supplied Authorization header)
+
+if [ -n "${SERVICE_TOKEN:-}" ]; then
+    export SEEBOM_AUTH_HEADER_VALUE="Bearer ${SERVICE_TOKEN}"
+else
+    export SEEBOM_AUTH_HEADER_VALUE=""
+fi
+

--- a/ui/nginx.conf.template
+++ b/ui/nginx.conf.template
@@ -1,3 +1,12 @@
+# If the client already supplied an Authorization header, pass it through.
+# Otherwise inject the SERVICE_TOKEN configured for the API Gateway (when
+# AUTH_ENABLED=true on the gateway). When SERVICE_TOKEN is empty,
+# SEEBOM_AUTH_HEADER_VALUE is empty and nginx omits the header entirely.
+map $http_authorization $seebom_effective_auth {
+    default $http_authorization;
+    ""      "${SEEBOM_AUTH_HEADER_VALUE}";
+}
+
 server {
     listen 80;
     server_name _;
@@ -22,12 +31,15 @@ server {
     }
 
     # Proxy API requests to the API Gateway service.
+    # When AUTH_ENABLED=true on the gateway, the UI is authenticated via the
+    # SERVICE_TOKEN injected here — the token never reaches the browser.
     location /api/ {
         proxy_pass http://api-gateway:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $seebom_effective_auth;
     }
 
     # Runtime config files: no cache so edits take effect on reload.


### PR DESCRIPTION
## Description
Implements **#134 — API Authentication** as a **fully optional, opt-in** feature. The middleware is disabled by default (`AUTH_ENABLED=false`), so existing deployments are completely unaffected.
Two authentication modes can be enabled independently or together:
1. **Service Token** — single shared secret for upstream proxy/gateway integrations (oauth2-proxy, Kong, custom auth)
2. **API Keys** — comma-separated list of pre-shared keys for direct consumers (CI/CD, scripts)
## Type of Change
- [x] ✨ New feature (non-breaking, opt-in)
- [x] 🔒 Security enhancement
- [x] 📝 Documentation update
## Component(s) Affected
- [x] API Gateway (new middleware)
- [x] Configuration (3 new env vars)
- [x] Documentation
- [ ] ClickHouse Schema
- [ ] Angular UI
- [ ] Helm Chart (env vars consumed via Helm `env`/`envFrom`)
## Related Issues
Closes #134
Unblocks #135 (SBOM Upload — needs auth gate before exposing write endpoint)
Unblocks #59 (Expose API externally — needs auth before public ingress)
## Configuration
| Env Var | Default | Purpose |
|---------|---------|---------|
| `AUTH_ENABLED` | `false` | Master switch |
| `SERVICE_TOKEN` | *(empty)* | Single shared secret |
| `API_KEYS` | *(empty)* | Comma-separated key list |
## Accepted Headers
| Header | Mode |
|--------|------|
| `Authorization: Bearer <token>` | Service token |
| `X-Service-Token: <token>` | Service token (alternative) |
| `X-API-Key: <key>` | API key |
## Security
- **Constant-time comparison** via `crypto/subtle.ConstantTimeCompare` — no timing attacks
- **WWW-Authenticate** header on 401 responses
- **Sanitized logging** of failed auth attempts (client IP via X-Forwarded-For, with newline stripping)
- **CORS** Allow-Headers extended to include `X-Service-Token` and `X-API-Key`
- **Misconfiguration warning** at startup if `AUTH_ENABLED=true` but no credentials configured
## Public Endpoints (always bypass auth)
| Endpoint | Reason |
|----------|--------|
| `/healthz` | K8s probe (current) |
| `/livez` | Reserved for #137 |
| `/readyz` | Reserved for #137 |
| `OPTIONS *` | CORS preflight |
## Middleware Ordering
```
securityHeaders → rateLimit → cors → auth → mux
```
Auth sits closest to the mux so 401 responses still receive CORS + security headers.
## How Has This Been Tested?
- [x] `go test ./...` passes (16 new tests)
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] All existing tests still pass
### New tests
**`backend/cmd/api-gateway/auth_test.go`** (12 tests):
- Auth disabled → all requests pass through
- Auth enabled, no credential → 401 with WWW-Authenticate
- Auth enabled, invalid token → 401
- Auth enabled, valid Bearer token → 200
- Auth enabled, valid X-Service-Token → 200
- Auth enabled, valid X-API-Key (multi-key) → 200
- Auth enabled, invalid API key → 401
- Service token + API keys coexist
- Public paths (`/healthz`, `/livez`, `/readyz`) bypass auth
- `OPTIONS` preflight bypasses auth
- Empty Bearer rejected
- `AUTH_ENABLED=true` with no credentials → all rejected (misconfiguration)
**`backend/internal/config/config_test.go`** (4 new tests):
- `TestLoad_Auth_DefaultsDisabled` — defaults all empty/false
- `TestLoad_Auth_ServiceTokenMode` — service token only
- `TestLoad_Auth_APIKeysMode` — multi-key parsing with whitespace trimming
- `TestLoad_Auth_EmptyAPIKeysString` — whitespace-only input returns nil
## Documentation
- **README.md** — `AUTH_ENABLED`, `SERVICE_TOKEN`, `API_KEYS` in env table
- **AGENTS.md** — Authentication section in API Gateway security hardening
- **docs/deployment** — New section "6. API Authentication (Optional)" with full K8s/Helm setup, Secret-based credential storage, when-to-enable guidance, security notes
- **docs/api-reference** — Replaced "Coming in v1.0" placeholder with full authentication reference including curl examples and response codes
## Backward Compatibility
✅ **100% backward compatible.** Default `AUTH_ENABLED=false` means existing deployments behave identically. The middleware is a zero-overhead pass-through when disabled.
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] I have added tests that prove my feature works (16 new tests)
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (4 doc files)
- [x] My changes generate no new warnings (vet clean)
- [x] I have signed off my commits (DCO)
## Out of Scope (Follow-ups)
- Helm chart env var wiring for `apiGateway.env` / `envFrom` Secret refs — pattern documented in deployment guide but requires Helm template updates in a separate PR
- OIDC / JWT token validation — explicitly out of scope per [ROADMAP.md](ROADMAP.md); user-facing auth is the upstream proxy responsibility
- Frontend (Angular) API client updates to inject tokens — only needed when UI is served via an authenticated ingress (separate config decision)
- Per-endpoint scopes / role-based access — auth is binary in v1; RBAC is a v2 consideration