### PR TITLE
feat(#139): headless mode (API-only deployment)

### DIFF
--- a/deploy/helm/seebom/templates/configmap-custom-theme.yaml
+++ b/deploy/helm/seebom/templates/configmap-custom-theme.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.customTheme.enabled }}
+{{- if and .Values.ui.enabled .Values.ui.customTheme.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/seebom/templates/configmap-nginx.yaml
+++ b/deploy/helm/seebom/templates/configmap-nginx.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ui.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -68,3 +69,4 @@ data:
         gzip_min_length 1000;
     }
 
+{{- end }}

--- a/deploy/helm/seebom/templates/configmap-ui-config.yaml
+++ b/deploy/helm/seebom/templates/configmap-ui-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.siteConfig.enabled }}
+{{- if and .Values.ui.enabled .Values.ui.siteConfig.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/seebom/templates/deployment-ui.yaml
+++ b/deploy/helm/seebom/templates/deployment-ui.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ui.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -93,3 +94,4 @@ spec:
             name: {{ .Release.Name }}-ui-config
         {{- end }}
 
+{{- end }}

--- a/deploy/helm/seebom/templates/service-ui.yaml
+++ b/deploy/helm/seebom/templates/service-ui.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ui.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,4 @@ spec:
     app.kubernetes.io/name: seebom
     app.kubernetes.io/component: ui
 
+{{- end }}

--- a/deploy/helm/seebom/values.yaml
+++ b/deploy/helm/seebom/values.yaml
@@ -155,7 +155,11 @@ apiGateway:
       apiKeysKey: "API_KEYS"
 
 # UI (Deployment)
+# Set ui.enabled to false for headless (API-only) deployments.
+# This skips all UI resources (Deployment, Service, ConfigMaps) and reduces
+# the resource footprint. All API endpoints remain fully functional.
 ui:
+  enabled: true
   replicas: 1
   service:
     type: ClusterIP

--- a/docs/content/docs/deployment/_index.md
+++ b/docs/content/docs/deployment/_index.md
@@ -389,7 +389,36 @@ helm install seebom ./deploy/helm/seebom \
 
 ---
 
-## 9. Verifying the Deployment
+## 9. Headless Mode (API-Only)
+
+For CI/CD integrations, custom dashboards, or environments where the Angular UI is not needed, SeeBOM can be deployed in **headless mode**. This skips all UI-related resources (Deployment, Service, nginx ConfigMap) and reduces the cluster's resource footprint.
+
+```yaml
+# values-headless.yaml
+ui:
+  enabled: false
+
+apiGateway:
+  auth:
+    enabled: true
+    serviceToken: "my-ci-token"
+```
+
+With `ui.enabled: false`:
+- No UI Deployment, Service, or ConfigMaps are rendered
+- All 19 API endpoints remain fully functional
+- The API Gateway is the only externally exposed component
+- Pair with `apiGateway.auth.enabled: true` to secure access
+
+This is ideal for:
+- **CI/CD pipelines** that push SBOMs and query results programmatically
+- **Grafana/custom dashboards** that consume the REST API directly
+- **Resource-constrained clusters** where every pod counts
+- **Air-gapped deployments** where the UI is served separately
+
+---
+
+## 10. Verifying the Deployment
 
 ```bash
 kubectl get pods -l app.kubernetes.io/name=seebom
@@ -413,4 +442,5 @@ kubectl exec -it $(kubectl get pod -l app.kubernetes.io/component=api-gateway -o
 | **Site Config** | ConfigMap | Helm values `ui.siteConfig.content.*` → restart UI |
 | **S3 credentials** | Secret | `--set s3.accessKey=...` or `s3.credentialsSecret` (existing K8s Secret) |
 | **API Authentication** | Env vars (Secret recommended) | `AUTH_ENABLED=true` + `SERVICE_TOKEN` and/or `API_KEYS`; off by default |
+| **Headless Mode** | Helm value | `ui.enabled: false` — skips UI Deployment/Service/ConfigMaps |
 

--- a/examples/kubernetes/values-headless.yaml
+++ b/examples/kubernetes/values-headless.yaml
@@ -1,0 +1,22 @@
+# values-headless.yaml – API-only deployment (no UI)
+#
+# Use this for CI/CD integrations, programmatic consumers, or
+# resource-constrained clusters where the Angular frontend is not needed.
+#
+# Usage:
+#   helm install seebom ./deploy/helm/seebom -f examples/kubernetes/values-headless.yaml
+#
+# All 19 REST API endpoints remain fully functional at the API Gateway service.
+
+# Disable the Angular UI entirely (no Deployment, Service, or ConfigMaps).
+ui:
+  enabled: false
+
+# Strongly recommended: enable authentication when running headless,
+# since there is no UI proxy to inject tokens automatically.
+apiGateway:
+  auth:
+    enabled: true
+    serviceToken: "CHANGE-ME"  # Replace with a real token
+    # apiKeys: "ci-pipeline-key,monitoring-key"
+


### PR DESCRIPTION
## Description
Add `ui.enabled` Helm value (default: `true`). When set to `false`, all UI-related Kubernetes resources are skipped — enabling pure API-only (headless) deployments for CI/CD pipelines, custom dashboards, and resource-constrained environments.
With `ui.enabled: false`:
- No UI Deployment, Service, or related ConfigMaps are rendered
- All 19 API endpoints remain fully functional
- Resource footprint is reduced (no nginx pods)
- Pair with `apiGateway.auth.enabled: true` for secure programmatic access
## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🏗️ Infrastructure / CI / Helm
## Component(s) Affected
- [ ] API Gateway
- [ ] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [x] Helm Chart
- [x] Documentation
## Related Issues
Closes #139
## How Has This Been Tested?
- [x] `go test ./...` passes
- [ ] `ng build` passes
- [x] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [x] Manual testing on Kubernetes
**Verification commands:**
```bash
# Headless: no UI resources rendered
helm template test deploy/helm/seebom --set ui.enabled=false | grep -E "name:.*-ui|component: ui"
# → no output (correct)
# Default: UI resources present
helm template test deploy/helm/seebom | grep -E "name:.*-ui|component: ui"
# → test-ui Deployment + Service + labels
# Lint both modes
helm lint deploy/helm/seebom
helm lint deploy/helm/seebom --set ui.enabled=false
# → 0 chart(s) failed
```
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)
## Screenshots (if applicable)
N/A — Helm-only change, no UI modifications.