### PR TITLE
feat(helm): add optional Ingress template (#59)

### DIFF
--- a/deploy/helm/seebom/templates/ingress.yaml
+++ b/deploy/helm/seebom/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ingress
+  labels:
+    app.kubernetes.io/name: seebom
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                {{- if .serviceSuffix }}
+                name: {{ $.Release.Name }}-{{ .serviceSuffix }}
+                {{- else }}
+                name: {{ $.Release.Name }}-api-gateway
+                {{- end }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/deploy/helm/seebom/values.yaml
+++ b/deploy/helm/seebom/values.yaml
@@ -162,15 +162,15 @@ ingress:
   className: ""   # e.g. "envoy", "contour", "alb"
   annotations: {}
     # cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: seebom.example.com
-      paths:
-        - path: /api
-          pathType: Prefix
-          # serviceSuffix defaults to "api-gateway" if omitted
-        - path: /
-          pathType: Prefix
-          serviceSuffix: ui
+  hosts: []
+    # - host: seebom.example.com
+    #   paths:
+    #     - path: /api
+    #       pathType: Prefix
+    #       # serviceSuffix defaults to "api-gateway" if omitted
+    #     - path: /
+    #       pathType: Prefix
+    #       serviceSuffix: ui
   tls: []
     # - secretName: seebom-tls
     #   hosts:

--- a/deploy/helm/seebom/values.yaml
+++ b/deploy/helm/seebom/values.yaml
@@ -154,6 +154,28 @@ apiGateway:
       serviceTokenKey: "SERVICE_TOKEN"
       apiKeysKey: "API_KEYS"
 
+# Ingress (optional – exposes the API Gateway and/or UI externally)
+# Works with any Ingress controller (Envoy Gateway, Contour, AWS ALB, etc.)
+# For Gateway API support, use a dedicated Gateway/HTTPRoute instead.
+ingress:
+  enabled: false
+  className: ""   # e.g. "envoy", "contour", "alb"
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          # serviceSuffix defaults to "api-gateway" if omitted
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+  tls: []
+    # - secretName: seebom-tls
+    #   hosts:
+    #     - seebom.example.com
+
 # UI (Deployment)
 # Set ui.enabled to false for headless (API-only) deployments.
 # This skips all UI resources (Deployment, Service, ConfigMaps) and reduces

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -474,6 +474,110 @@ cp .env.example .env
 
 ---
 
+## 9. Ingress – Exposing the API Externally
+
+SeeBOM includes an optional Ingress resource to expose the API Gateway (and optionally the UI) outside the cluster. The template is controller-agnostic — it works with any Ingress controller that implements the Kubernetes Ingress spec (Envoy Gateway, Contour, AWS ALB, etc.).
+
+> **Note:** For the newer [Gateway API](https://gateway-api.sigs.k8s.io/), configure Gateway/HTTPRoute resources separately. The Helm chart provides the classic Ingress resource.
+
+### Basic (HTTP only, Envoy Gateway)
+
+```yaml
+ingress:
+  enabled: true
+  className: eg
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+```
+
+### With TLS (cert-manager)
+
+```yaml
+ingress:
+  enabled: true
+  className: eg
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+  tls:
+    - secretName: seebom-tls
+      hosts:
+        - seebom.example.com
+```
+
+### Contour Example
+
+```yaml
+ingress:
+  enabled: true
+  className: contour
+  annotations:
+    projectcontour.io/tls-cert-namespace: cert-manager
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+  tls:
+    - secretName: seebom-tls
+      hosts:
+        - seebom.example.com
+```
+
+### API-only (headless, no UI)
+
+```yaml
+ingress:
+  enabled: true
+  className: eg
+  hosts:
+    - host: api.seebom.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+> **Security Note:** When exposing the API externally, ensure `apiGateway.auth.enabled: true` is set. Without authentication, all SBOM data is publicly accessible.
+
+### AWS ALB Example
+
+```yaml
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:...
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+```
+
+---
+
 ## Summary
 
 | What | Where | How to Change |
@@ -488,3 +592,4 @@ cp .env.example .env
 | **Dark Mode** | Built-in toggle (navbar) | User preference, stored in browser localStorage |
 | **ClickHouse password** | `seebom-secret` Secret | `kubectl edit secret` |
 | **S3 credentials** | `seebom-secret` Secret | `--set s3.accessKey=...` or `kubectl edit secret` |
+| **Ingress** | `seebom-ingress` Ingress resource | `ingress.enabled: true` + configure hosts/tls in Helm values |

--- a/docs/content/docs/deployment/_index.md
+++ b/docs/content/docs/deployment/_index.md
@@ -418,7 +418,109 @@ This is ideal for:
 
 ---
 
-## 10. Verifying the Deployment
+## 10. Ingress – Exposing the API Externally
+
+SeeBOM includes an optional Ingress resource to expose the API Gateway (and optionally the UI) outside the cluster. The template is controller-agnostic — it works with any Ingress controller that implements the Kubernetes Ingress spec (Envoy Gateway, Contour, AWS ALB, etc.).
+
+{{% alert title="Gateway API" color="info" %}}
+For the newer [Gateway API](https://gateway-api.sigs.k8s.io/), configure Gateway/HTTPRoute resources separately. The Helm chart provides the classic Ingress resource.
+{{% /alert %}}
+
+### Basic (Envoy Gateway)
+
+```yaml
+ingress:
+  enabled: true
+  className: eg
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+```
+
+### With TLS (cert-manager)
+
+```yaml
+ingress:
+  enabled: true
+  className: eg
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+  tls:
+    - secretName: seebom-tls
+      hosts:
+        - seebom.example.com
+```
+
+### Contour
+
+```yaml
+ingress:
+  enabled: true
+  className: contour
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+```
+
+### AWS ALB
+
+```yaml
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:...
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+  hosts:
+    - host: seebom.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /
+          pathType: Prefix
+          serviceSuffix: ui
+```
+
+### API-only (headless)
+
+```yaml
+ingress:
+  enabled: true
+  className: eg
+  hosts:
+    - host: api.seebom.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+{{% alert title="Security" color="warning" %}}
+When exposing the API externally, ensure `apiGateway.auth.enabled: true` is set. Without authentication, all SBOM data is publicly accessible.
+{{% /alert %}}
+
+---
+
+## 11. Verifying the Deployment
 
 ```bash
 kubectl get pods -l app.kubernetes.io/name=seebom
@@ -443,4 +545,4 @@ kubectl exec -it $(kubectl get pod -l app.kubernetes.io/component=api-gateway -o
 | **S3 credentials** | Secret | `--set s3.accessKey=...` or `s3.credentialsSecret` (existing K8s Secret) |
 | **API Authentication** | Env vars (Secret recommended) | `AUTH_ENABLED=true` + `SERVICE_TOKEN` and/or `API_KEYS`; off by default |
 | **Headless Mode** | Helm value | `ui.enabled: false` — skips UI Deployment/Service/ConfigMaps |
-
+| **Ingress** | Ingress resource | `ingress.enabled: true` + configure hosts/tls in Helm values |


### PR DESCRIPTION
## Summary
Adds an optional, controller-agnostic Ingress resource to the Helm chart for exposing the API Gateway and UI externally.
## Changes
- **New template**: `deploy/helm/seebom/templates/ingress.yaml`
  - Gated by `ingress.enabled: false` (default off)
  - Supports any IngressClass (Envoy Gateway, Contour, AWS ALB, etc.)
  - Configurable: `className`, `annotations`, `hosts` (with `serviceSuffix` for API/UI routing), `tls`
- **Values**: New `ingress.*` section with sensible defaults
- **Docs**: Section 9 in DEPLOYMENT_GUIDE with examples for Envoy Gateway, Contour, AWS ALB, and headless API-only mode
- **No nginx-ingress references** — deprecated/EOL, only CNCF projects as examples
## Testing
- `helm template` validated: enabled/disabled, TLS, annotations, multiple className values
- Template renders correct `networking.k8s.io/v1` Ingress with proper service backends
## Checklist
- [x] Helm template renders correctly
- [x] Default (disabled) produces no Ingress resource
- [x] Deployment Guide updated (Section 9)
- [x] AGENTS.md template count updated (19 → 20)
- [x] ARCHITECTURE_PLAN template count updated
Closes #59