### PR TITLE
fix(docker): pin UI builder to host platform — fixes ARM64 QEMU crash

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,7 @@
 # ---- Build stage ----
-FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS builder
+# Pin to host platform to avoid QEMU emulation for npm ci (ARM64 crashes under QEMU).
+# The output is static HTML/JS/CSS — platform-independent.
+FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS builder
 
 WORKDIR /app
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Problem
The v0.5.0 release build fails on the UI image when building for `linux/arm64`:
```
#27 [linux/arm64 builder 4/6] RUN npm ci
#27 22.52 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```
`npm ci` under QEMU ARM64 emulation crashes due to native binaries in `node_modules` that don't work under instruction-level emulation.
## Fix
Pin the builder stage to `$BUILDPLATFORM` (the GitHub Actions runner = amd64), so `npm ci` and `ng build` always run natively. The output is static HTML/JS/CSS — completely platform-independent.
The nginx serve stage remains multi-platform (`linux/amd64` + `linux/arm64`) since nginx's alpine image supports both natively.
## Change
```dockerfile
-FROM node:22-alpine@sha256:... AS builder
+FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:... AS builder
```
After merge, the v0.5.0 release workflow needs to be re-triggered.