### PR TITLE
fix(ci): bump Go to 1.25.11 in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Go (for Hugo modules)
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache-dependency-path: docs/go.sum
 
       - name: Install Node.js


### PR DESCRIPTION
The deploy-docs workflow fails because `docs/go.mod` now requires `go >= 1.25.11` but the workflow installs `1.25` (resolves to 1.25.10) with `GOTOOLCHAIN=local`.
```
go: go.mod requires go >= 1.25.11 (running go 1.25.10; GOTOOLCHAIN=local)
```
Fix: pin `go-version: '1.25.11'` in the setup-go action.
Ref: https://github.com/seebom-labs/seebom/actions/runs/26882430640