### PR TITLE
fix(docs): keep SEO URLs on HTTPS so Google indexes the docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -68,10 +68,17 @@ jobs:
           HUGO_ENVIRONMENT: production
           TZ: UTC
         run: |
+          # NOTE: We intentionally do NOT pass --baseURL here. The Hugo
+          # `baseURL` in docs/hugo.toml is the canonical HTTPS custom domain
+          # (https://docs.bomhort.dev/). The `actions/configure-pages` output
+          # `base_url` resolves the custom domain with an *http://* scheme,
+          # which would poison every canonical link, og:url, and sitemap <loc>
+          # with http:// — causing Google to treat the pages as redirect/
+          # duplicate targets and skip indexing. Relying on hugo.toml keeps all
+          # SEO URLs on https://.
           hugo \
             --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+            --minify
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
## Description
The public documentation site (https://docs.bomhort.dev) was not being indexed by Google due to an **HTTP/HTTPS canonical mismatch**.
The site is served over HTTPS, but every SEO-relevant URL pointed to `http://`:
- `<link rel="canonical" href="http://docs.bomhort.dev/">`
- `og:url`, `og:image`, `twitter:image`
- `schema.org` `url`
- **the entire `sitemap.xml`** (`<loc>http://docs.bomhort.dev/...</loc>`)
Because `http://` redirects to `https://`, Google treated the pages as redirect/duplicate targets ("Alternate page with proper canonical tag" / "Page with redirect") and skipped indexing.
**Root cause:** the deploy workflow overrode Hugo's correct HTTPS `baseURL` (from `docs/hugo.toml`) with the `actions/configure-pages` `base_url` output, which resolves the custom domain with an `http://` scheme:
```yaml
hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"   # → http://docs.bomhort.dev/
```
**Fix:** drop the `--baseURL` override so Hugo uses the canonical HTTPS `baseURL` already defined in `docs/hugo.toml` (`https://docs.bomhort.dev/`). Added an explanatory comment so it is not reintroduced.
## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🏗️ Infrastructure / CI / Helm
## Component(s) Affected
- [ ] API Gateway
- [ ] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [ ] Helm Chart
- [x] Documentation
## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->
## How Has This Been Tested?
Built the docs locally without the `--baseURL` override and verified the emitted URLs:
- `sitemap.xml` → `<loc>https://docs.bomhort.dev/docs/</loc>` ✅
- canonical tag → `<link rel="canonical" href="https://docs.bomhort.dev/">` ✅
- [ ] `go test ./...` passes
- [ ] `ng build` passes
- [ ] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes
- [x] Local Hugo build verifies HTTPS canonical + sitemap URLs
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)
## Follow-up (post-merge, manual)
- Re-submit `https://docs.bomhort.dev/sitemap.xml` in Google Search Console and request indexing for a few core URLs.
- Confirm "Enforce HTTPS" is enabled in the GitHub Pages settings.
