### PR TITLE
chore(release): bump chart to 0.6.0 and refresh RELEASE.md

### DIFF
--- a/deploy/helm/bomhort/Chart.yaml
+++ b/deploy/helm/bomhort/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bomhort
 description: BOMHort - Kubernetes-native SBOM visualization and governance platform
 type: application
-version: 0.1.3
-appVersion: "0.1.3"
+version: 0.6.0
+appVersion: "0.6.0"
 keywords:
   - sbom
   - spdx

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # BOMHort – Release & Publishing Guide
 
-> **Updated:** 2026-05-05
+> **Updated:** 2026-07-23
 
 ---
 
@@ -43,8 +43,8 @@ Fix any reported vulnerabilities before proceeding. Check all three ecosystems (
 ### 2. Tag the release
 
 ```bash
-git tag v0.1.2
-git push origin v0.1.2
+git tag v0.6.0
+git push origin v0.6.0
 ```
 
 ### 3. What happens automatically
@@ -53,7 +53,7 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) triggers on any `v
 
 1. **Builds all 5 container images** (multi-arch: amd64 + arm64)
 2. **Pushes them to ghcr.io** with two tags each:
-   - `ghcr.io/seebom-labs/bomhort/<component>:0.1.2` (version)
+   - `ghcr.io/seebom-labs/bomhort/<component>:0.6.0` (version)
    - `ghcr.io/seebom-labs/bomhort/<component>:latest`
 3. **Packages the Helm chart** with the matching version
 4. **Pushes the Helm chart** as an OCI artifact to `oci://ghcr.io/seebom-labs/bomhort/charts`
@@ -75,10 +75,10 @@ Release notes are grouped by PR labels (see `.github/release.yml`):
 
 ```bash
 # Check images exist
-docker pull ghcr.io/seebom-labs/bomhort/api-gateway:0.1.2
+docker pull ghcr.io/seebom-labs/bomhort/api-gateway:0.6.0
 
 # Check Helm chart
-helm show chart oci://ghcr.io/seebom-labs/bomhort/charts/bomhort --version 0.1.2
+helm show chart oci://ghcr.io/seebom-labs/bomhort/charts/bomhort --version 0.6.0
 ```
 
 ---
@@ -89,7 +89,7 @@ helm show chart oci://ghcr.io/seebom-labs/bomhort/charts/bomhort --version 0.1.2
 
 ```bash
 helm install bomhort oci://ghcr.io/seebom-labs/bomhort/charts/bomhort \
-  --version 0.1.2 \
+  --version 0.6.0 \
   -f values-production.yaml
 ```
 
@@ -97,8 +97,8 @@ helm install bomhort oci://ghcr.io/seebom-labs/bomhort/charts/bomhort \
 
 ```bash
 helm install bomhort oci://ghcr.io/seebom-labs/bomhort/charts/bomhort \
-  --version 0.1.2 \
-  --set image.tag=0.1.2
+  --version 0.6.0 \
+  --set image.tag=0.6.0
 ```
 
 ---
@@ -123,8 +123,8 @@ If you contribute via a fork:
 2. **Merge the PR** into `main` of the main repo
 3. **Tag in the main repo** (not in the fork):
    ```bash
-   git tag v0.1.2
-   git push origin v0.1.2
+   git tag v0.6.0
+   git push origin v0.6.0
    ```
 
 > **Do not tag releases in your fork.** The `GITHUB_TOKEN` in a fork cannot push images to the main repo's GHCR, and the GitHub Release would be created in the fork instead of the main repo.
@@ -180,7 +180,7 @@ docker build -t my-registry/bomhort/ui:test ui/
 The backend uses a **single multi-stage Dockerfile** (`backend/Dockerfile`) with three named targets:
 
 ```
-golang:1.24-alpine (builder)
+golang:1.25-alpine (builder)
   ├── go build → /bin/ingestion-watcher
   ├── go build → /bin/parsing-worker
   ├── go build → /bin/api-gateway
@@ -208,8 +208,8 @@ All runtime images run as `nobody:nobody` (backend) or `nginx` (UI) for security
 
 ## Versioning
 
-- **Git tags**: `v0.1.2`, `v0.2.0`, etc. (SemVer)
-- **Image tags**: `0.1.3` (without `v` prefix) + `latest`
+- **Git tags**: `v0.6.0`, `v0.7.0`, etc. (SemVer)
+- **Image tags**: `0.6.0` (without `v` prefix) + `latest`
 - **Helm chart version**: Matches the Git tag (auto-updated by CI)
 - `values.yaml` defaults to the latest released tag
 
@@ -223,12 +223,12 @@ To use a different registry, override in Helm:
 helm install bomhort oci://ghcr.io/seebom-labs/bomhort/charts/bomhort \
   --set image.registry=my-registry.example.com \
   --set image.repository=my-org/bomhort \
-  --set image.tag=0.1.3
+  --set image.tag=0.6.0
 ```
 
 Or build + push locally:
 
 ```bash
-make images-push REGISTRY=my-registry.example.com REPO=my-org/bomhort TAG=0.1.3
+make images-push REGISTRY=my-registry.example.com REPO=my-org/bomhort TAG=0.6.0
 ```
 


### PR DESCRIPTION
## Description

Release-prep for **v0.6.0**: bump the Helm chart version and refresh the release guide so the documented examples match the upcoming tag.

- `deploy/helm/bomhort/Chart.yaml`: `version` + `appVersion` `0.1.3` → **`0.6.0`**
- `docs/RELEASE.md`:
  - all version examples (`git tag`, `docker pull`, `helm install/show`, private-registry) `0.1.2`/`0.1.3` → **`0.6.0`**
  - corrected the builder base image in the Image Architecture section: `golang:1.24-alpine` → **`golang:1.25-alpine`** (matches `backend/Dockerfile`)
  - refreshed the "Updated" date to 2026-07-23

No functional/runtime changes — chart templates and app code are untouched.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [x] 🏗️ Infrastructure / CI / Helm

## Component(s) Affected

- [ ] API Gateway
- [ ] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [x] Helm Chart
- [x] Documentation

## Related Issues

<!-- Release prep for v0.6.0 -->

## How Has This Been Tested?

- `helm lint deploy/helm/bomhort` → 0 failures.
- Verified no stale `0.1.x` version strings remain in `docs/RELEASE.md`.

- [ ] `go test ./...` passes
- [ ] `ng build` passes
- [x] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes

## Checklist

- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [ ] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)

## Screenshots (if applicable)

<!-- N/A -->

