### PR TITLE
fix(ci): lowercase repository name for GHCR in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
             target: ""
     steps:
       - name: Normalize repository name (GHCR requires lowercase)
-        run: echo "REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          REPO=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "REPO=$REPO" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -102,7 +104,9 @@ jobs:
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Normalize repository name (GHCR requires lowercase)
-        run: echo "REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          REPO=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "REPO=$REPO" >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         id: version
@@ -136,7 +140,9 @@ jobs:
           fetch-depth: 0
 
       - name: Normalize repository name (GHCR requires lowercase)
-        run: echo "REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          REPO=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "REPO=$REPO" >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,10 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  REPO: ${{ github.repository }}
+  # REPO is normalized to lowercase per job via the "Normalize repository name"
+  # step, because GHCR image names must be lowercase and GitHub Actions
+  # expressions have no lower() function. github.repository can contain
+  # uppercase letters (e.g. seebom-labs/BOMHort).
 
 jobs:
   images:
@@ -39,6 +42,9 @@ jobs:
             context: ui
             target: ""
     steps:
+      - name: Normalize repository name (GHCR requires lowercase)
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -95,6 +101,9 @@ jobs:
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
+      - name: Normalize repository name (GHCR requires lowercase)
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
@@ -125,6 +134,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+
+      - name: Normalize repository name (GHCR requires lowercase)
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             target: ""
     steps:
       - name: Normalize repository name (GHCR requires lowercase)
-        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+        run: echo "REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -102,7 +102,7 @@ jobs:
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Normalize repository name (GHCR requires lowercase)
-        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+        run: echo "REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         id: version
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
 
       - name: Normalize repository name (GHCR requires lowercase)
-        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+        run: echo "REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Description
The **v0.6.0 release workflow failed** because, after the `seebom → BOMHort` repository rename, `github.repository` now resolves to `seebom-labs/BOMHort` (mixed case). GHCR image names **must be lowercase**, so the build errored:
```
ERROR: failed to build: invalid tag "ghcr.io/seebom-labs/BOMHort/ingestion-watcher:0.6.0": repository name must be lowercase
```
GitHub Actions expressions have no `lower()` function, so this normalizes `GITHUB_REPOSITORY` to lowercase via a shell step (`${GITHUB_REPOSITORY,,}` → `$GITHUB_ENV` as `REPO`) in **each of the three jobs** (`images`, `helm`, `github-release`). The un-lowercased global `env.REPO` was removed.
This affects image tags, cosign signing, provenance attestation, the Helm chart OCI push, and the release-body `docker pull` commands — all now use the lowercase repo path.
## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] 🏗️ Infrastructure / CI / Helm
## Component(s) Affected
- [x] Helm Chart
- [x] Documentation
## How Has This Been Tested?
- YAML validated (`yaml.safe_load`).
- Verified all 12 `env.REPO` usages remain and each job sets a lowercased `REPO` before first use.
- Will be confirmed by re-running the release once the tag is moved to this commit.
- [x] `helm lint` passes (unchanged chart)
## Note
Because tag `push` events use the workflow file **at the tagged commit**, `v0.6.0` must be re-pointed to the merge commit of this PR and force-pushed to re-trigger the release (a plain re-run would reuse the buggy file).
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)