### PR TITLE
fix(docker): bump UI builder node to v22.23.1 (fixes v0.6.0 release build)

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,7 +1,7 @@
 # ---- Build stage ----
 # Pin to host platform to avoid QEMU emulation for npm ci (ARM64 crashes under QEMU).
 # The output is static HTML/JS/CSS — platform-independent.
-FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS builder
+FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
 
 WORKDIR /app
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Description
The re-triggered **v0.6.0 release** got past the GHCR lowercase fix but then the **UI image build failed**:
```
The Angular CLI requires a minimum Node.js version of v22.22.3 or v24.15.0 or v26.0.0.
ERROR: process "/bin/sh -c npx ng build --configuration=production" did not complete successfully: exit code: 3
```
The pinned `node:22-alpine` digest (`8ea2348…`) resolved to **v22.22.2**, just below Angular 22's engine requirement (`^22.22.3`). Re-pinned to the current `node:22-alpine` **manifest-list** digest (`16e22a55…` = **v22.23.1**), covering linux/amd64 + linux/arm64.
## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🏗️ Infrastructure / CI / Helm
## Component(s) Affected
- [x] Angular UI
## How Has This Been Tested?
- `docker build --target builder` locally → `ng build` completes (`Output location: /app/dist/ui`), only pre-existing CSS budget warnings.
- Digest verified: `docker run node:22-alpine@sha256:16e22a55… node -v` → `v22.23.1`.
- Manifest-list digest confirmed via `docker buildx imagetools inspect` (includes amd64 + arm64) — not guessed.
- [x] `ng build` passes
## Checklist
- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] My changes generate no new warnings
- [x] I have signed off my commits (DCO)