### PR TITLE
docs(roadmap): add Tier-2 SBOM fidelity capture as v1.0 blocker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # BOMHort Product Roadmap
 
-> Last updated: 2026-07-15
+> Last updated: 2026-07-25
 > Project Board: https://github.com/orgs/seebom-labs/projects/1
 
 ## Executive Summary
@@ -43,6 +43,7 @@ The sequencing is driven by dependency chains: multi-cluster support must land b
 | ~~#132~~ | ~~Cluster listing endpoint~~ | ✅ **Done** — `GET /api/v1/clusters`. |
 | ~~#133~~ | ~~Cluster-detail endpoints~~ | ✅ **Done** — `GET /api/v1/clusters/{name}/stats` and `/sboms`. |
 | ~~#135~~ | ~~SBOM Upload (Push Model)~~ | ✅ **Done** — `POST /api/v1/sboms/upload`. Requires `AUTH_ENABLED=true` (self-enforced by the handler). Routes to a `skipScan` S3 bucket or `SBOM_DIR/pushed/`, then enqueues a normal ingestion job. |
+| #256 | Tier-2 fidelity capture (persist original SBOM bytes at ingest) | **v1.0 blocker.** Forward-only: originals can only be captured at ingest, so this must land before 1.0 or historical SBOMs permanently lose round-trip/export fidelity under infinite retention. Bytes go to a configurable blob store (source S3 bucket under an ignored prefix, dedicated bucket, or volume) — **not** ClickHouse. Bundles with #135/#144; batch its additive migration with the #57 `ADD COLUMN` wave. Enables #255. |
 | #138 | Namespace filtering | Sub-cluster granularity. Enterprise teams operate in namespaces, not just clusters. |
 | #140 | Workload vulnerability summary | The key cross-reference: image → posture. Powers compliance dashboards. |
 | #62 | Exportable Auditor Reports (PDF/CSV) | CRA compliance requires offline documentation. Auditors don't use UIs. |
@@ -73,6 +74,7 @@ After Phase 2 completes, BOMHort reaches **v1.0.0** — the first stable release
 - [x] ~~CycloneDX parsing~~ (#55)
 - [x] ~~Health probes~~ (#137)
 - [ ] Versioned docs (#145)
+- [ ] Tier-2 fidelity capture: persist original SBOM at ingest (#256)
 
 ---
 
@@ -90,6 +92,7 @@ After Phase 2 completes, BOMHort reaches **v1.0.0** — the first stable release
 | #61 | OpenSSF Scorecard Integration | Upstream project health scoring. "Is this dependency well-maintained?" |
 | #82 | Lottery Factor | Single-maintainer risk detection. Supply chain resilience metric. |
 | #7 | CVE Fix Time (MTTR) | Mean-time-to-remediate is a key security KPI for audits (SOC2, ISO 27001). |
+| #255 | Editable/enriched SBOMs + enriched download (+ companion VEX + in-toto re-sign) | Enrich SBOMs with BOMHort data (resolved licenses, VEX, vuln context), then download an updated, standards-valid SBOM. Additive (new tables + endpoints), so post-1.0-safe without a major bump. Builds on #256 (fidelity capture). Overlay is `ReplacingMergeTree`-versioned (latest-wins); enriched export can be wrapped in a fresh in-toto attestation and cosign-signed with BOMHort as the transforming instance. |
 
 **Exit criteria:** BOMHort provides CRA readiness scoring, exploit-probability-based prioritization, dependency health metrics, and SBOM diff capabilities.
 
@@ -111,6 +114,8 @@ After Phase 2 completes, BOMHort reaches **v1.0.0** — the first stable release
                           └── Per-project policies (license, severity, exceptions)
 
 #143 (Witness) ── standalone (feeds into #141 CRA Dashboard)
+#256 (Fidelity capture) ──┬── bundles with #135 (Upload), #144 (Download)
+                          └── enables #255 (Enriched SBOM download + in-toto re-sign)
 #55 (CycloneDX) ── standalone
 #144 (SBOM Download) ── standalone
 #137 (Health Checks) ── standalone


### PR DESCRIPTION
## What

Adds the **Tier-2 SBOM fidelity capture** work to the roadmap as a **v1.0 blocker**, plus the follow-on enriched-SBOM feature as a post-1.0 item.

## Why

Came out of evaluating protobom/storage's SQL schemas ([protobom/storage#101](https://github.com/protobom/storage/pull/101)) and its merged ClickHouse backend ([protobom/storage#102](https://github.com/protobom/storage/pull/102)). Conclusion: a **two-tier** model — keep the ClickHouse analytical store as-is (Tier 1, our fast query/search plane), and add a **source-of-record** tier that preserves the original SBOM so we can later edit/enrich it and download an updated, standards-valid document.

The fidelity-capture half (#256) is **forward-only**: originals can only be captured at ingest, so any SBOM ingested before it lands permanently loses round-trip/export fidelity under infinite retention. That — not the schema freeze — is what makes it a **pre-1.0** requirement.

## Changes

- **Phase 2** table: new row **#256** (persist original SBOM bytes at ingest; configurable blob store — source S3 bucket under an ignored prefix, dedicated bucket, or volume; **not** ClickHouse). Bundles with #135/#144, batched with the #57 migration wave.
- **v1.0 criteria** checklist: add #256.
- **Phase 3** table: new row **#255** (editable/enriched SBOMs + enriched download + companion OpenVEX + optional in-toto re-sign). Additive, post-1.0-safe.
- **Dependency graph**: #256 bundles with #135/#144 and enables #255.

## Notes

- Design decisions, schema sketch (`013_create_document_store`, `014_create_enrichment_overlay`), storage-backend choice, in-toto re-signing feasibility, and a breaking-change assessment are recorded in #254, #255, #256.
- **Non-breaking:** all additive (new tables + opt-in endpoints); filesystem-only deployments use a volume, so object storage is never forced. The only breaking change on the horizon (converging the Tier-1 query schema to protobom's wide `nodes`/`edges`) is deferred to **v2.0** behind a major bump.

Refs: #254, #255, #256
